### PR TITLE
Run dart2native on SDKs that use it instead of dart2aot

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -24,8 +24,8 @@ import 'package:pub_semver/pub_semver.dart';
 
 import 'info.dart';
 
-/// The set of entrypoint for executables defined by this package.
-Set<String> get entrypoints => executables.values.toSet();
+/// The set of entrypoint paths for executables defined by this package.
+Set<String> get entrypoints => p.PathSet.of(executables.values);
 
 /// The version of the current Dart executable.
 final Version dartVersion = Version.parse(Platform.version.split(" ").first);

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -53,6 +53,19 @@ final dotBat = Platform.isWindows ? ".bat" : "";
 /// The `.exe` extension on Windows, the empty string everywhere else.
 final dotExe = Platform.isWindows ? ".exe" : "";
 
+/// The path to the `dart2native` executable in the Dart SDK.
+final dart2NativePath = p.join(sdkDir.path, 'bin/dart2native$dotBat');
+
+/// Whether we should compile native executables using `dart2native` rather than
+/// `dart2aot`.
+///
+/// Dart 2.6 and up uses an executable called "dart2native" to generate both
+/// bundled native code executables AND native snapshot "AOT" executables which
+/// need to be run with `dartaotruntime`. Earlier SDK versions use a different
+/// executable, `dart2aot`, which has a different calling convention and only
+/// generates "AOT" snapshots. We support both.
+final useDart2Native = File(dart2NativePath).existsSync();
+
 /// Ensure that the `build/` directory exists.
 void ensureBuild() {
   Directory('build').createSync(recursive: true);

--- a/test/standalone_test.dart
+++ b/test/standalone_test.dart
@@ -205,7 +205,7 @@ void main() {
           workingDirectory: d.sandbox);
       expect(executable.stdout, emits("in foo"));
       await executable.shouldExit(0);
-    });
+    }, onPlatform: {"windows": Skip("google/dart_cli_pkg#25")});
   }, onPlatform: {if (!useDart2Native) "windows": Skip("dart-lang/sdk#37897")});
 
   test("includes the package's license and Dart's license", () async {

--- a/test/standalone_test.dart
+++ b/test/standalone_test.dart
@@ -88,7 +88,7 @@ void main() {
       await d.archive("my_app/build/my-sa-app-1.2.3-$_archiveSuffix",
           [d.dir("my-sa-app")]).validate();
     });
-  }, onPlatform: {"windows": Skip("dart-lang/sdk#37897")});
+  }, onPlatform: {if (!useDart2Native) "windows": Skip("dart-lang/sdk#37897")});
 
   group("executables", () {
     var pubspec = {
@@ -206,7 +206,7 @@ void main() {
       expect(executable.stdout, emits("in foo"));
       await executable.shouldExit(0);
     });
-  }, onPlatform: {"windows": Skip("dart-lang/sdk#37897")});
+  }, onPlatform: {if (!useDart2Native) "windows": Skip("dart-lang/sdk#37897")});
 
   test("includes the package's license and Dart's license", () async {
     await d
@@ -228,7 +228,7 @@ void main() {
         d.file("DART_LICENSE", contains("Dart project authors"))
       ])
     ]).validate();
-  }, onPlatform: {"windows": Skip("dart-lang/sdk#37897")});
+  }, onPlatform: {if (!useDart2Native) "windows": Skip("dart-lang/sdk#37897")});
 
   group("creates a package for", () {
     setUp(() => d
@@ -291,7 +291,9 @@ void main() {
         await archive("my_app/build/my_app-1.2.3-windows-x64.zip",
                 windows: true)
             .validate();
-      }, onPlatform: {"windows": Skip("dart-lang/sdk#37897")});
+      }, onPlatform: {
+        if (!useDart2Native) "windows": Skip("dart-lang/sdk#37897")
+      });
     });
 
     test("all platforms", () async {
@@ -307,6 +309,8 @@ void main() {
         archive("my_app/build/my_app-1.2.3-windows-x64.zip", windows: true)
             .validate()
       ]);
-    }, onPlatform: {"windows": Skip("dart-lang/sdk#37897")});
+    }, onPlatform: {
+      if (!useDart2Native) "windows": Skip("dart-lang/sdk#37897")
+    });
   });
 }


### PR DESCRIPTION
This doesn't actually generate standalone native executables yet, it
just uses dart2native to generate native snapshots ("AOT mode").