### PR TITLE
More gracefully handle prerelease versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.0-beta.4
+
+* Add a `pkg.npmDistTag` getter that controls the distribution tag for an npm
+  release.
+
 # 1.0.0-beta.3
 
 * Add a `cli_pkg/testing.dart` library to make it easier for users to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * Add a `pkg.npmDistTag` getter that controls the distribution tag for an npm
   release.
 
+* Add a `pkg.homebrewCreateVersionedFormula` getter that controls whether the
+  Homebrew release creates a new formula or updates an existing one.
+
 # 1.0.0-beta.3
 
 * Add a `cli_pkg/testing.dart` library to make it easier for users to

--- a/doc/homebrew.md
+++ b/doc/homebrew.md
@@ -22,7 +22,7 @@ repo.
 Uses configuration: [`pkg.version`][], [`pkg.humanName`][], [`pkg.botName`][],
 [`pkg.botEmail`][], [`pkg.githubRepo`][], [`pkg.githubUser`][],
 [`pkg.githubPassword`][], [`pkg.homebrewRepo`][], [`pkg.homebrewFormula`][],
-[`pkg.homebrewTag`][]
+[`pkg.homebrewTag`][], [`pkg.homebrewCreateVersionedFormula`][]
 
 [`pkg.version`]: https://pub.dev/documentation/cli_pkg/latest/cli_pkg/version.html
 [`pkg.humanName`]: https://pub.dev/documentation/cli_pkg/latest/cli_pkg/humanName.html
@@ -33,6 +33,7 @@ Uses configuration: [`pkg.version`][], [`pkg.humanName`][], [`pkg.botName`][],
 [`pkg.homebrewRepo`]: https://pub.dev/documentation/cli_pkg/latest/cli_pkg/homebrewRepo.html
 [`pkg.homebrewFormula`]: https://pub.dev/documentation/cli_pkg/latest/cli_pkg/homebrewFormula.html
 [`pkg.homebrewTag`]: https://pub.dev/documentation/cli_pkg/latest/cli_pkg/homebrewTag.html
+[`pkg.homebrewCreateVersionedFormula`]: https://pub.dev/documentation/cli_pkg/latest/cli_pkg/homebrewCreateVersionedFormula.html
 
 Checks out [`pkg.homebrewRepo`][] and pushes a commit updating
 [`pkg.homebrewFormula`][]'s `url` and `sha256` fields to point to the

--- a/doc/npm.md
+++ b/doc/npm.md
@@ -77,9 +77,10 @@ Depends on: [`pkg-js-dev`][]
 
 [`pkg-js-dev`]: #pkg-js-dev
 
-Uses configuration: [`pkg.executables`][], [`pkg.version`][], [`pkg.npmPackageJson`][], [`pkg.jsModuleMainLibrary`][], [`pkg.npmReadme`][]
+Uses configuration: [`pkg.executables`][], [`pkg.version`][], [`pkg.npmPackageJson`][], [`pkg.jsModuleMainLibrary`][], [`pkg.npmReadme`][], [`pkg.npmDistTag`][]
 
 [`pkg.npmReadme`]: https://pub.dev/documentation/cli_pkg/latest/cli_pkg/npmReadme.html
+[`pkg.npmDistTag`]: https://pub.dev/documentation/cli_pkg/latest/cli_pkg/npmDistTag.html
 
 Output: `build/npm/*`
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_pkg
-version: 1.0.0-beta.3
+version: 1.0.0-beta.4
 description: Grinder tasks for releasing Dart CLI packages.
 homepage: https://github.com/google/dart_cli_pkg
 

--- a/test/npm_test.dart
+++ b/test/npm_test.dart
@@ -391,6 +391,57 @@ void main() {
     });
   });
 
+  group("npmDistTag", () {
+    test('defaults to "latest" for a non-prerelease', () async {
+      await d.package(pubspec, """
+        void main(List<String> args) {
+          print(pkg.npmDistTag);
+        }
+      """, [_packageJson]).create();
+
+      var grinder = await grind(["pkg-npm-dev"]);
+      await expect(grinder.stdout, emits("latest"));
+      await grinder.shouldExit();
+    });
+
+    test("defaults to a prerelease identifier", () async {
+      await d.package({...pubspec, "version": "1.2.3-foo.4.bar"}, """
+        void main(List<String> args) {
+          print(pkg.npmDistTag);
+        }
+      """, [_packageJson]).create();
+
+      var grinder = await grind(["pkg-npm-dev"]);
+      await expect(grinder.stdout, emits("foo"));
+      await grinder.shouldExit();
+    });
+
+    test('defaults to "pre" for a prerelease without an identifier', () async {
+      await d.package({...pubspec, "version": "1.2.3-4.foo"}, """
+        void main(List<String> args) {
+          print(pkg.npmDistTag);
+        }
+      """, [_packageJson]).create();
+
+      var grinder = await grind(["pkg-npm-dev"]);
+      await expect(grinder.stdout, emits("pre"));
+      await grinder.shouldExit();
+    });
+
+    test("can be overridden", () async {
+      await d.package(pubspec, """
+        void main(List<String> args) {
+          pkg.npmDistTag = "qux";
+          print(pkg.npmDistTag);
+        }
+      """, [_packageJson]).create();
+
+      var grinder = await grind(["pkg-npm-dev"]);
+      await expect(grinder.stdout, emits("qux"));
+      await grinder.shouldExit();
+    });
+  });
+
   group("README.md", () {
     test("isn't added if it doesn't exist on disk", () async {
       await d.package(pubspec, _enableNpm, [_packageJson]).create();


### PR DESCRIPTION
On npm, prerelease versions should generally not have the "latest" tag
or it'll start installing them by default rather than the latest
stable version.

On Homebrew, prerelease versions should generally create new formula
files rather than updating the primary formula file (which represents
the stable version).