### PR TITLE
Fix two documentation bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ It's strongly recommended that this package be imported with the prefix `pkg`.
 
 ### Configuration
 
-This package is highly configurable, using properties defined [at the top level
-of the library][]. By default, it infers as much configuration as possible from
-the package's pubspec, but almost all properties can be overridden in the
-`main()` method:
+This package is highly configurable, using properties defined
+[at the top level of the library][]. By default, it infers as much configuration
+as possible from the package's pubspec, but almost all properties can be
+overridden in the `main()` method:
 
 [at the top level of the library]: https://pub.dev/documentation/sass/latest/sass/sass-library.html#properties
 

--- a/doc/npm.md
+++ b/doc/npm.md
@@ -2,6 +2,7 @@ These tasks compile the package to JavaScript, build [npm][] packages, and
 upload them to the npm registry. They're enabled by calling
 [`pkg.addNpmTasks()`][].
 
+[npm]: https://www.npmjs.com
 [`pkg.addNpmTasks()`]: https://pub.dev/documentation/cli_pkg/latest/cli_pkg/addNpmTasks.html
 
 Note that all JS compilation requires that a `package.json` file exist at the


### PR DESCRIPTION
See two current markdown rendering issues:

1. https://pub.dev/packages/cli_pkg#configuration
2. https://github.com/google/dart_cli_pkg/blob/master/doc/npm.md

This fixes each. The first fix is unfortunate, as the markdown is valid, but there is a bug in the Dart markdown package: https://github.com/dart-lang/markdown/issues/281.