### PR TITLE
removed unused dart:async

### DIFF
--- a/lib/src/github.dart
+++ b/lib/src/github.dart
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 


### PR DESCRIPTION
removed unused dart:async as Future and Streams are already implemented in dart:core as per Dart 2.1.