### PR TITLE
Improve error handling when nuspec does not exist

### DIFF
--- a/lib/src/chocolatey.dart
+++ b/lib/src/chocolatey.dart
@@ -126,13 +126,7 @@ List<String> _chocolateyFiles;
 /// `cli_pkg` will automatically add a `"version"` field and a dependency on the
 /// Dart SDK when building the Chocolatey package.
 String get chocolateyNuspec {
-  if (_chocolateyNuspec != null) {
-    if (Directory(_chocolateyNuspec).existsSync()) {
-      return _chocolateyNuspec;
-    } else {
-      fail("pkg.chocolateyNuspec: $_chocolateyNuspec does not exist.");
-    }
-  }
+  if (_chocolateyNuspec != null) return _chocolateyNuspec;
 
   var possibleNuspecs = [
     for (var entry in Directory(".").listSync())
@@ -140,7 +134,8 @@ String get chocolateyNuspec {
   ];
 
   if (possibleNuspecs.isEmpty) {
-    fail("pkg.chocolateyNuspec must be set to build a Chocolatey package.");
+    fail(
+        "Please add a .nuspec file to the root of the repository or pkg.chocolateyNuspec must be set to build a Chocolatey package.");
   } else if (possibleNuspecs.length > 1) {
     fail("pkg.chocolateyNuspec found multiple .nuspec files: " +
         possibleNuspecs.join(", "));

--- a/lib/src/chocolatey.dart
+++ b/lib/src/chocolatey.dart
@@ -126,7 +126,13 @@ List<String> _chocolateyFiles;
 /// `cli_pkg` will automatically add a `"version"` field and a dependency on the
 /// Dart SDK when building the Chocolatey package.
 String get chocolateyNuspec {
-  if (_chocolateyNuspec != null) return _chocolateyNuspec;
+  if (_chocolateyNuspec != null) {
+    if (Directory(_chocolateyNuspec).existsSync()) {
+      return _chocolateyNuspec;
+    } else {
+      fail("pkg.chocolateyNuspec: $_chocolateyNuspec does not exist.");
+    }
+  }
 
   var possibleNuspecs = [
     for (var entry in Directory(".").listSync())


### PR DESCRIPTION
When configuring `pkg.chocolateyNuspec` if the configured file is not found a message `Invalid nuspec: "<" expected at 1:1` is shown. This checks if the configured file exists before trying to load it and parse it.