### PR TITLE
INCORRECT Dart sdk license lookup

### DIFF
--- a/lib/src/chocolatey.dart
+++ b/lib/src/chocolatey.dart
@@ -126,13 +126,7 @@ List<String> _chocolateyFiles;
 /// `cli_pkg` will automatically add a `"version"` field and a dependency on the
 /// Dart SDK when building the Chocolatey package.
 String get chocolateyNuspec {
-  if (_chocolateyNuspec != null) {
-    if (Directory(_chocolateyNuspec).existsSync()) {
-      return _chocolateyNuspec;
-    } else {
-      fail("pkg.chocolateyNuspec: $_chocolateyNuspec does not exist.");
-    }
-  }
+  if (_chocolateyNuspec != null) return _chocolateyNuspec;
 
   var possibleNuspecs = [
     for (var entry in Directory(".").listSync())
@@ -140,7 +134,8 @@ String get chocolateyNuspec {
   ];
 
   if (possibleNuspecs.isEmpty) {
-    fail("pkg.chocolateyNuspec must be set to build a Chocolatey package.");
+    fail(
+        "Please add a .nuspec file to the root of the repository or pkg.chocolateyNuspec must be set to build a Chocolatey package.");
   } else if (possibleNuspecs.length > 1) {
     fail("pkg.chocolateyNuspec found multiple .nuspec files: " +
         possibleNuspecs.join(", "));

--- a/lib/src/chocolatey.dart
+++ b/lib/src/chocolatey.dart
@@ -126,7 +126,13 @@ List<String> _chocolateyFiles;
 /// `cli_pkg` will automatically add a `"version"` field and a dependency on the
 /// Dart SDK when building the Chocolatey package.
 String get chocolateyNuspec {
-  if (_chocolateyNuspec != null) return _chocolateyNuspec;
+  if (_chocolateyNuspec != null) {
+    if (Directory(_chocolateyNuspec).existsSync()) {
+      return _chocolateyNuspec;
+    } else {
+      fail("pkg.chocolateyNuspec: $_chocolateyNuspec does not exist.");
+    }
+  }
 
   var possibleNuspecs = [
     for (var entry in Directory(".").listSync())

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -85,14 +85,12 @@ Future<String> get license => _licenseMemo.runOnce(() async {
       // from Dart Team packages.
       var licenses = <String, List<String>>{};
       var thisPackageLicense = _readLicense(".");
+
       if (thisPackageLicense != null) {
         licenses[thisPackageLicense] = [humanName];
       }
 
-      licenses
-          .putIfAbsent(
-              File(p.join(sdkDir.path, 'LICENSE')).readAsStringSync(), () => [])
-          .add("Dart SDK");
+      licenses.putIfAbsent(_readSdkLicense(), () => []).add("Dart SDK");
 
       // Parse the package config rather than the pubspec so we include transitive
       // dependencies. This also includes dev dependencies, but it's possible those
@@ -130,6 +128,19 @@ final _licenseMemo = AsyncMemoizer<String>();
 /// licenses.
 final _licenseRegExp =
     RegExp(r"^(([a-zA-Z0-9]+[-_])?(LICENSE|COPYING)|UNLICENSE)(\..*)?$");
+
+/// Returns the contents of the `LICENSE` file in [sdkDir],
+String _readSdkLicense() {
+  final dartLicense = File(p.join(sdkDir.path, 'LICENSE'));
+
+  if (dartLicense.existsSync()) {
+    return dartLicense.readAsStringSync();
+  } else {
+    // Look up parent directory for license
+    // If not in the main directory
+    return File(p.join(sdkDir.parent.path, 'LICENSE')).readAsStringSync();
+  }
+}
 
 /// Returns the contents of the `LICENSE` file in [dir], with various possible
 /// filenames and extensions, or `null`.


### PR DESCRIPTION
This closes #39.

If you have installed Dart SDK through homebrew this is a show stopper and requires to manually move the LICENSE file.