### PR TITLE
Added parent look up for dart-sdk license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.0-beta.11
+
+* Properly load the Dart SDK license when it's in the directory above the SDK,
+  as in a Homebrew installation.
+
 # 1.0.0-beta.10
 
 * **Breaking change:** All configurable variables are now defined as

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -85,14 +85,12 @@ Future<String> get license => _licenseMemo.runOnce(() async {
       // from Dart Team packages.
       var licenses = <String, List<String>>{};
       var thisPackageLicense = _readLicense(".");
+
       if (thisPackageLicense != null) {
         licenses[thisPackageLicense] = [humanName];
       }
 
-      licenses
-          .putIfAbsent(
-              File(p.join(sdkDir.path, 'LICENSE')).readAsStringSync(), () => [])
-          .add("Dart SDK");
+      licenses.putIfAbsent(_readSdkLicense(), () => []).add("Dart SDK");
 
       // Parse the package config rather than the pubspec so we include transitive
       // dependencies. This also includes dev dependencies, but it's possible those
@@ -130,6 +128,19 @@ final _licenseMemo = AsyncMemoizer<String>();
 /// licenses.
 final _licenseRegExp =
     RegExp(r"^(([a-zA-Z0-9]+[-_])?(LICENSE|COPYING)|UNLICENSE)(\..*)?$");
+
+/// Returns the contents of the `LICENSE` file in [sdkDir],
+String _readSdkLicense() {
+  final dartLicense = File(p.join(sdkDir.path, 'LICENSE'));
+
+  if (dartLicense.existsSync()) {
+    return dartLicense.readAsStringSync();
+  } else {
+    // Look up parent directory for license
+    // If not in the main directory
+    return File(p.join(sdkDir.parent.path, 'LICENSE')).readAsStringSync();
+  }
+}
 
 /// Returns the contents of the `LICENSE` file in [dir], with various possible
 /// filenames and extensions, or `null`.

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -129,15 +129,15 @@ final _licenseMemo = AsyncMemoizer<String>();
 final _licenseRegExp =
     RegExp(r"^(([a-zA-Z0-9]+[-_])?(LICENSE|COPYING)|UNLICENSE)(\..*)?$");
 
-/// Returns the contents of the `LICENSE` file in [sdkDir],
+/// Returns the contents of the `LICENSE` file in [sdkDir].
 String _readSdkLicense() {
   final dartLicense = File(p.join(sdkDir.path, 'LICENSE'));
 
   if (dartLicense.existsSync()) {
     return dartLicense.readAsStringSync();
   } else {
-    // Look up parent directory for license
-    // If not in the main directory
+    // Homebrew's Dart SDK installation puts the license in the directory above
+    // the SDK, so if it's not in the SDK itself check there.
     return File(p.join(sdkDir.parent.path, 'LICENSE')).readAsStringSync();
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_pkg
-version: 1.0.0-beta.10
+version: 1.0.0-beta.11
 description: Grinder tasks for releasing Dart CLI packages.
 homepage: https://github.com/google/dart_cli_pkg
 


### PR DESCRIPTION
This closes #39.

If you have installed Dart SDK through homebrew this is a show stopper and requires to manually move the LICENSE file.