### PR TITLE
Re-enable Travis tests for Dart dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: dart
 
 dart:
 - stable
-# Testing on Dart dev is temporarily disabled due to dart-lang/sdk#44064.
-# - dev
+- dev
 
 os:
 - linux

--- a/test/descriptor.dart
+++ b/test/descriptor.dart
@@ -41,6 +41,7 @@ final _ourPubpsec = loadYaml(File('pubspec.yaml').readAsStringSync(),
 DirectoryDescriptor package(Map<String, Object> pubspec, String grindDotDart,
     [List<Descriptor> files]) {
   pubspec = {
+    "environment": _ourPubpsec["environment"],
     "executables": <String, Object>{},
     ...pubspec,
     "dev_dependencies": {


### PR DESCRIPTION
We need to copy over our environment setting so Dart doesn't think
we're using the latest language version with null-aware operations.