### PR TITLE
Migrate to null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.0
+
+* Migrate to null-safety.
+
 # 1.2.0
 
 * Add a `pkg.githubBearerToken` to make it easier to integrate with GitHub

--- a/lib/src/chocolatey.dart
+++ b/lib/src/chocolatey.dart
@@ -128,6 +128,7 @@ final chocolateyNuspec = InternalConfigVariable.fn<String>(() {
   return File(possibleNuspecs.single).readAsStringSync();
 });
 
+// TODO: late
 /// Returns the XML-decoded contents of [chocolateyNuspecText], with a
 /// `"version"` field and a dependency on the Dart SDK automatically added.
 XmlDocument get _nuspec {
@@ -148,7 +149,7 @@ XmlDocument get _nuspec {
   metadata.children
       .add(XmlElement(XmlName("version"), [], [XmlText(_chocolateyVersion)]));
 
-  var dependencies = _findElement(metadata, "dependencies", allowNone: true);
+  var dependencies = _findElementAllowNone(metadata, "dependencies");
   if (dependencies == null) {
     dependencies = XmlElement(XmlName("dependencies"));
     metadata.children.add(dependencies);
@@ -288,22 +289,35 @@ Future<void> _deploy() async {
 }
 
 /// Returns the single child of [parent] named [name], or throws an error.
-///
-/// If [allowNone] is `true`, this returns `null` if there are no children of
-/// [parent] named [name]. Otherwise, it throws an error.
-XmlElement _findElement(XmlNode parent, String name, {bool allowNone = false}) {
+XmlElement _findElement(XmlNode parent, String name) {
   var elements = parent.findElements(name);
   if (elements.length == 1) return elements.single;
-  if (allowNone && elements.isEmpty) return null;
 
+  var path = _pathToElement(parent, name);
+  fail(elements.isEmpty
+      ? "The nuspec must have a $path element."
+      : "The nuspec may not have multiple $path elements.");
+}
+
+/// Like [findElement], but returns `null` if there are no children of [parent]
+/// named [name].
+XmlElement _findElementAllowNone(XmlNode parent, String name) {
+  var elements = parent.findElements(name);
+  if (elements.length == 1) return elements.single;
+  if (elements.isEmpty) return null;
+
+  var path = _pathToElement(parent, name);
+  fail("The nuspec may not have multiple $path elements.");
+}
+
+/// Returns a human-readable CSS-formatted path to the element named [name]
+/// within [parent].
+String _pathToElement(XmlNode/*!*/ parent, String name) {
   var nesting = [name];
   while (parent is XmlElement) {
     nesting.add((parent as XmlElement).name.qualified);
     parent = parent.parent;
   }
 
-  var path = nesting.reversed.join(" > ");
-  fail(elements.isEmpty
-      ? "The nuspec must have a $path element."
-      : "The nuspec may not have multiple $path elements.");
+  return nesting.reversed.join(" > ");
 }

--- a/lib/src/chocolatey.dart
+++ b/lib/src/chocolatey.dart
@@ -128,10 +128,9 @@ final chocolateyNuspec = InternalConfigVariable.fn<String>(() {
   return File(possibleNuspecs.single).readAsStringSync();
 });
 
-/// TODO: late
 /// Returns the XML-decoded contents of [chocolateyNuspecText], with a
 /// `"version"` field and a dependency on the Dart SDK automatically added.
-final XmlDocument _nuspec = () {
+late final XmlDocument _nuspec = () {
   XmlDocument nuspec;
 
   try {

--- a/lib/src/chocolatey.dart
+++ b/lib/src/chocolatey.dart
@@ -139,7 +139,7 @@ late final XmlDocument _nuspec = () {
     fail("Invalid nuspec: $error");
   }
 
-  var metadata = _nuspecMetadata;
+  var metadata = _findElement(nuspec.rootElement, "metadata");
   if (metadata.findElements("version").isNotEmpty) {
     fail("The nuspec must not have a package > metadata > version element. One "
         "will be added automatically.");

--- a/lib/src/chocolatey.dart
+++ b/lib/src/chocolatey.dart
@@ -128,14 +128,14 @@ final chocolateyNuspec = InternalConfigVariable.fn<String>(() {
   return File(possibleNuspecs.single).readAsStringSync();
 });
 
-// TODO: late
+/// TODO: late
 /// Returns the XML-decoded contents of [chocolateyNuspecText], with a
 /// `"version"` field and a dependency on the Dart SDK automatically added.
-XmlDocument get _nuspec {
-  if (__nuspec != null) return __nuspec;
+final XmlDocument _nuspec = () {
+  XmlDocument nuspec;
 
   try {
-    __nuspec = XmlDocument.parse(chocolateyNuspec.value);
+    nuspec = XmlDocument.parse(chocolateyNuspec.value);
   } on XmlParserException catch (error) {
     fail("Invalid nuspec: $error");
   }
@@ -163,10 +163,8 @@ XmlDocument get _nuspec {
     XmlAttribute(XmlName("version"), "[$chocolateyDartVersion]")
   ]));
 
-  return __nuspec;
-}
-
-XmlDocument __nuspec;
+  return nuspec;
+}();
 
 /// The `metadata` element in [_nuspec].
 XmlElement get _nuspecMetadata => _findElement(_nuspec.rootElement, "metadata");
@@ -301,7 +299,7 @@ XmlElement _findElement(XmlNode parent, String name) {
 
 /// Like [findElement], but returns `null` if there are no children of [parent]
 /// named [name].
-XmlElement _findElementAllowNone(XmlNode parent, String name) {
+XmlElement? _findElementAllowNone(XmlNode parent, String name) {
   var elements = parent.findElements(name);
   if (elements.length == 1) return elements.single;
   if (elements.isEmpty) return null;
@@ -312,10 +310,10 @@ XmlElement _findElementAllowNone(XmlNode parent, String name) {
 
 /// Returns a human-readable CSS-formatted path to the element named [name]
 /// within [parent].
-String _pathToElement(XmlNode/*!*/ parent, String name) {
+String _pathToElement(XmlNode? parent, String name) {
   var nesting = [name];
   while (parent is XmlElement) {
-    nesting.add((parent as XmlElement).name.qualified);
+    nesting.add(parent.name.qualified);
     parent = parent.parent;
   }
 

--- a/lib/src/config_variable.dart
+++ b/lib/src/config_variable.dart
@@ -19,12 +19,12 @@
 /// `tool/grind.dart`, before any `add*Tasks()` functions are called.
 class ConfigVariable<T> {
   /// The cached value.
-  T/*?*/ _value;
+  T? _value;
 
   /// The variable's original value,
   ///
   /// This is always set if `_defaultCallback` is null.
-  T/*?*/ _defaultValue;
+  T? _defaultValue;
 
   /// Whether [_value] has been cached yet or not.
   ///
@@ -36,22 +36,22 @@ class ConfigVariable<T> {
   ///
   /// This can only be null if [_value] has been set explicitly and [_cached] is
   /// `true`.
-  T Function()/*?*/ _callback;
+  T Function()? _callback;
 
   /// The original callback for generating [_value].
-  T Function()/*?*/ _defaultCallback;
+  T Function()? _defaultCallback;
 
   /// Whether this variable has been frozen and can no longer be modified by the
   /// user.
   var _frozen = false;
 
   /// A function to call to make [_value] unmodifiable.
-  final T Function(T)/*?*/ _freeze;
+  final T Function(T)? _freeze;
 
   /// The variable's value.
-  T/*!*/ get value {
+  T get value {
     if (!_cached) {
-      _value = _callback/*!*/();
+      _value = _callback!();
       _cached = true;
     }
 
@@ -75,12 +75,12 @@ class ConfigVariable<T> {
 
   /// Returns the default value for this variable, even if its value has since
   /// been overridden.
-  T/*!*/ get defaultValue {
+  T get defaultValue {
     var defaultCallback = _defaultCallback;
     // We can't use `!` for `_defaultValue` because `T` might itself be a
     // nullable type. We don't necessarily know that `_value` isn't null, we
     // just know that it's the value returned by `_callback`.
-    return defaultCallback == null ? _defaultValue as T/*!*/ : defaultCallback();
+    return defaultCallback == null ? _defaultValue as T : defaultCallback();
   }
 
   /// Sets the variable's value to the result of calling [callback].
@@ -99,11 +99,11 @@ class ConfigVariable<T> {
     _cached = false;
   }
 
-  ConfigVariable._fn(this._callback, {T Function(T)/*?*/ freeze})
+  ConfigVariable._fn(this._callback, {T Function(T)? freeze})
       : _defaultCallback = _callback,
         _freeze = freeze;
 
-  ConfigVariable._value(this._value, {T Function(T)/*?*/ freeze})
+  ConfigVariable._value(this._value, {T Function(T)? freeze})
       : _defaultValue = _value,
         _cached = true,
         _freeze = freeze;
@@ -112,20 +112,20 @@ class ConfigVariable<T> {
 }
 
 /// Expose extension methods so we can hide them from external users.
-extension InternalConfigVariable<T> on ConfigVariable<T/*!*/> {
+extension InternalConfigVariable<T> on ConfigVariable<T> {
   /// Creates a configuration variable whose value defaults to the result of the
   /// given [_callback].
   ///
   /// If [freeze] is passed, it's called when the variable is frozen to make the
   /// value unmodifiable as well.
-  static ConfigVariable<T> fn<T>(T callback(), {T Function(T)/*?*/ freeze}) =>
+  static ConfigVariable<T> fn<T>(T callback(), {T Function(T)? freeze}) =>
       ConfigVariable._fn(callback, freeze: freeze);
 
   /// Creates a configuration variable with the given [value].
   ///
   /// If [freeze] is passed, it's called when the variable is frozen to make the
   /// value unmodifiable as well.
-  static ConfigVariable<T> value<T>(T value, {T Function(T)/*?*/ freeze}) =>
+  static ConfigVariable<T> value<T>(T value, {T Function(T)? freeze}) =>
       ConfigVariable._value(value, freeze: freeze);
 
   /// Marks the variable as unmodifiable.
@@ -139,9 +139,9 @@ extension InternalConfigVariable<T> on ConfigVariable<T/*!*/> {
         // We can't use `!` for `_value` because `T` might itself be a nullable
         // type. We don't necessarily know that `_value` isn't null, we just
         // know that it's the value returned by `_callback`.
-        _value = freeze(_value as T/*!*/);
+        _value = freeze(_value as T);
       } else {
-        var oldCallback = _callback/*!*/;
+        var oldCallback = _callback!;
         _callback = () => freeze(oldCallback());
       }
     }

--- a/lib/src/github.dart
+++ b/lib/src/github.dart
@@ -33,7 +33,7 @@ import 'utils.dart';
 /// Git URL, this must be set explicitly.
 final githubRepo = InternalConfigVariable.fn<String>(() =>
     _repoFromOrigin() ??
-    _repoFromPubspec() ??
+    _parseHttp(pubspec.homepage) ??
     fail("pkg.githubRepo must be set to deploy to GitHub."));
 
 /// Returns the GitHub repo name from the Git configuration's
@@ -48,10 +48,6 @@ String _repoFromOrigin() {
     return null;
   }
 }
-
-/// Returns the GitHub repo name from the pubspec's `homepage` field.
-String _repoFromPubspec() =>
-    pubspec.homepage == null ? null : _parseHttp(pubspec.homepage);
 
 /// Parses a GitHub repo name from an SSH reference or a `git://` URL.
 ///

--- a/lib/src/github.dart
+++ b/lib/src/github.dart
@@ -298,7 +298,7 @@ Future<void> _uploadExecutables(String os) async {
   ].map((architecture) async {
     var format = os == "windows" ? "zip" : "tar.gz";
     var package = "$standaloneName-$version-$os-$architecture.$format";
-    var response = await client.post("$uploadUrl?name=$package",
+    var response = await client.post(Uri.parse("$uploadUrl?name=$package"),
         headers: {
           "content-type":
               os == "windows" ? "application/zip" : "application/gzip",

--- a/lib/src/github.dart
+++ b/lib/src/github.dart
@@ -168,7 +168,7 @@ Future<void> _release() async {
       body: jsonEncode({
         "tag_name": version.toString(),
         "name": "$humanName $version",
-        "prerelease": version!.isPreRelease,
+        "prerelease": version.isPreRelease,
         if (githubReleaseNotes.value != null) "body": githubReleaseNotes.value
       }));
 

--- a/lib/src/homebrew.dart
+++ b/lib/src/homebrew.dart
@@ -20,6 +20,7 @@ import 'utils.dart';
 ///
 /// This must be set explicitly.
 final homebrewRepo = InternalConfigVariable.fn<String>(
+    // TODO: delete as
     () => fail("pkg.homebrewRepo must be set to deploy to Homebrew."));
 
 /// The path to the formula file within the Homebrew repository to update with

--- a/lib/src/homebrew.dart
+++ b/lib/src/homebrew.dart
@@ -34,10 +34,8 @@ final homebrewFormula = InternalConfigVariable.value<String?>(null);
 /// `@`-versioned formula file for the current version number.
 ///
 /// By default, this is `true` if and only if [version] is a prerelease version.
-final homebrewCreateVersionedFormula = InternalConfigVariable.fn<bool>(() =>
-    version?.isPreRelease ??
-    fail("pkg.homebrewCreateVersionedFormula must be explicitly set if no "
-        "pubspec version exists."));
+final homebrewCreateVersionedFormula =
+    InternalConfigVariable.fn(() => version.isPreRelease);
 
 /// Whether [addHomebrewTasks] has been called yet.
 var _addedHomebrewTasks = false;
@@ -100,7 +98,7 @@ Future<void> _update() async {
     formula = _replaceFirstMappedMandatory(
         formula,
         RegExp(r'^ *class ([^ <]+) *< *Formula *$', multiLine: true),
-        (match) => 'class ${match[1]}AT${_classify(version!)} < Formula',
+        (match) => 'class ${match[1]}AT${_classify(version)} < Formula',
         "Couldn't find a Formula subclass in $formulaPath.");
 
     var newFormulaPath = p.join(p.dirname(formulaPath),

--- a/lib/src/homebrew.dart
+++ b/lib/src/homebrew.dart
@@ -20,8 +20,7 @@ import 'utils.dart';
 ///
 /// This must be set explicitly.
 final homebrewRepo = InternalConfigVariable.fn<String>(
-    // TODO: delete as
-    (() => fail("pkg.homebrewRepo must be set to deploy to Homebrew.")) as String Function());
+    () => fail("pkg.homebrewRepo must be set to deploy to Homebrew."));
 
 /// The path to the formula file within the Homebrew repository to update with
 /// the new package version.

--- a/lib/src/info.dart
+++ b/lib/src/info.dart
@@ -61,7 +61,7 @@ final botEmail = InternalConfigVariable.fn<String>(() => "cli_pkg@none");
 /// may be modified, but the values must be paths to executable files in the
 /// package.
 final executables = InternalConfigVariable.fn<Map<String, String>>(() {
-  var executables = rawPubspec['executables'] as Map<Object, Object>;
+  var executables = rawPubspec['executables'] as Map<Object, Object>?;
 
   return {
     for (var entry in (executables ?? {}).entries)

--- a/lib/src/info.dart
+++ b/lib/src/info.dart
@@ -14,7 +14,9 @@
 
 import 'dart:io';
 
+import 'package:grinder/grinder.dart';
 import 'package:path/path.dart' as p;
+import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
 
 import 'config_variable.dart';
@@ -28,7 +30,12 @@ final pubspec = Pubspec.parse(File('pubspec.yaml').readAsStringSync(),
 final dartName = pubspec.name;
 
 /// The package's version, as specified in the pubspec.
-final version = pubspec.version;
+final Version version = () {
+  var version = pubspec.version;
+  if (version != null) return version;
+
+  fail("The pubspec must declare a version number.");
+}();
 
 /// The default name of the package on package managers other than pub.
 ///

--- a/lib/src/info.dart
+++ b/lib/src/info.dart
@@ -61,7 +61,7 @@ final botEmail = InternalConfigVariable.fn<String>(() => "cli_pkg@none");
 /// may be modified, but the values must be paths to executable files in the
 /// package.
 final executables = InternalConfigVariable.fn<Map<String, String>>(() {
-  var executables = rawPubspec['executables'] as Map<Object, Object>?;
+  var executables = rawPubspec['executables'] as Map<dynamic, dynamic>?;
 
   return {
     for (var entry in (executables ?? {}).entries)

--- a/lib/src/info.dart
+++ b/lib/src/info.dart
@@ -22,7 +22,7 @@ import 'utils.dart';
 
 /// The parsed pubspec for the CLI package.
 final pubspec = Pubspec.parse(File('pubspec.yaml').readAsStringSync(),
-    sourceUrl: 'pubspec.yaml');
+    sourceUrl: Uri(path: 'pubspec.yaml'));
 
 /// The name of the package, as specified in the pubspec.
 final dartName = pubspec.name;

--- a/lib/src/npm.dart
+++ b/lib/src/npm.dart
@@ -102,7 +102,7 @@ final jsModuleMainLibrary = InternalConfigVariable.value<String>(null);
 final npmPackageJson = InternalConfigVariable.fn<Map<String, Object>>(
     () => File("package.json").existsSync()
         ? jsonDecode(File("package.json").readAsStringSync())
-            as Map<String, Object>
+            as Map<String, Object>/*!*/
         : fail("pkg.npmPackageJson must be set to build an npm package."),
     freeze: freezeJsonMap);
 
@@ -227,7 +227,7 @@ void _js({@required bool release}) {
       // complain. We replace those with direct references to the modules, which
       // we load explicitly after the preamble.
       .replaceAllMapped(RegExp(r'self\.require\(("[^"]+")\)'), (match) {
-    var package = jsonDecode(match[1]) as String;
+    var package = jsonDecode(match[1]) as String/*!*/;
     var identifier = requires.entries
         .firstWhere((entry) => entry.value == package, orElse: () => null)
         ?.key;
@@ -261,6 +261,7 @@ void _js({@required bool release}) {
   destination.writeAsStringSync(buffer.toString());
 }
 
+// TODO: late
 /// A map from executable names in [executables] to JS- and Dart-safe
 /// identifiers to use to identify those modules.
 Map<String, String> get _executableIdentifiers {
@@ -381,9 +382,8 @@ module.${_executableIdentifiers[name]}(process.argv.slice(2));
 """);
   }
 
-  if (npmReadme.value != null) {
-    writeString('build/npm/README.md', npmReadme.value);
-  }
+  var readme = npmReadme.value;
+  if (readme != null) writeString('build/npm/README.md', readme);
 
   writeString(p.join(dir.path, "LICENSE"), await license);
 }

--- a/lib/src/npm.dart
+++ b/lib/src/npm.dart
@@ -99,10 +99,10 @@ final jsModuleMainLibrary = InternalConfigVariable.value<String?>(null);
 /// `cli_pkg` will automatically add `"version"` and `"bin"` fields when
 /// building the npm package. If [jsModuleMainLibrary] is set, it will also add
 /// a `"main"` field.
-final npmPackageJson = InternalConfigVariable.fn<Map<String, Object>>(
+final npmPackageJson = InternalConfigVariable.fn<Map<String, dynamic>>(
     () => File("package.json").existsSync()
         ? jsonDecode(File("package.json").readAsStringSync())
-            as Map<String, Object>
+            as Map<String, dynamic>
         : fail("pkg.npmPackageJson must be set to build an npm package."),
     freeze: freezeJsonMap);
 
@@ -337,12 +337,12 @@ class _Exports {""");
   // Dart list, if `main()` takes arguments.
   wrapper.writeln("""
 Function _wrapMain(Function main) {
-  if (main is Object Function()) {
+  if (main is dynamic Function()) {
     return allowInterop((_) => _translateReturnValue(main()));
   } else {
     return allowInterop(
         (args) => _translateReturnValue(
-            main(List<String>.from(args as List<Object>))));
+            main(List<String>.from(args as List<dynamic>))));
   }
 }""");
 

--- a/lib/src/npm.dart
+++ b/lib/src/npm.dart
@@ -150,11 +150,8 @@ final npmToken = InternalConfigVariable.fn<String>(() =>
 ///
 /// * For other prerelease versions, `"pre"`.
 final npmDistTag = InternalConfigVariable.fn<String>(() {
-  if (version == null) {
-    fail("pkg.npmDistTag must be set explicitly if no pubspec version exists.");
-  }
-  if (version!.preRelease.isEmpty) return "latest";
-  var firstComponent = version!.preRelease[0];
+  if (version.preRelease.isEmpty) return "latest";
+  var firstComponent = version.preRelease[0];
   return firstComponent is String ? firstComponent : "pre";
 });
 

--- a/lib/src/npm.dart
+++ b/lib/src/npm.dart
@@ -17,7 +17,6 @@ import 'dart:io';
 
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:grinder/grinder.dart';
-import 'package:meta/meta.dart';
 import 'package:node_preamble/preamble.dart' as preamble;
 import 'package:path/path.dart' as p;
 
@@ -265,10 +264,9 @@ void _js({required bool release}) {
   destination.writeAsStringSync(buffer.toString());
 }
 
-/// TODO: late
 /// A map from executable names in [executables] to JS- and Dart-safe
 /// identifiers to use to identify those modules.
-final Map<String, String> _executableIdentifiers = () {
+late final Map<String, String> _executableIdentifiers = () {
   var i = 0;
   return {
     // Add a trailing underscore to indicate that the name is intended to be
@@ -367,7 +365,7 @@ Future<void> _buildPackage() async {
       jsonEncode({
         ...npmPackageJson.value,
         "version": version.toString(),
-        "bin": {for (var name in executables.value.keys) name: "${name}.js"},
+        "bin": {for (var name in executables.value.keys) name: "$name.js"},
         if (jsModuleMainLibrary.value != null) "main": "$_npmName.dart.js"
       }));
 

--- a/lib/src/npm.dart
+++ b/lib/src/npm.dart
@@ -299,7 +299,7 @@ String get _wrapperLibrary {
   // Define a JS-interop Future to Promise translator so that we can export
   // a Promise-based API
   wrapper.writeln("""
-Object _translateReturnValue(Object val) {
+dynamic _translateReturnValue(dynamic val) {
   if (val is Future) {
     return futureToPromise(val);
   } else {

--- a/lib/src/pub.dart
+++ b/lib/src/pub.dart
@@ -30,10 +30,10 @@ final String _credentialsPath = () {
   if (pubCache != null) {
     cacheDir = pubCache;
   } else if (Platform.isWindows) {
-    var appData = Platform.environment['APPDATA'];
+    var appData = Platform.environment['APPDATA']!;
     cacheDir = p.join(appData, 'Pub', 'Cache');
   } else {
-    cacheDir = p.join(Platform.environment['HOME'], '.pub-cache');
+    cacheDir = p.join(Platform.environment['HOME']!, '.pub-cache');
   }
 
   return p.join(cacheDir, 'credentials.json');

--- a/lib/src/pub.dart
+++ b/lib/src/pub.dart
@@ -26,8 +26,9 @@ final String _credentialsPath = () {
   // This follows the same logic as pub:
   // https://github.com/dart-lang/pub/blob/d99b0d58f4059d7bb4ac4616fd3d54ec00a2b5d4/lib/src/system_cache.dart#L34-L43
   String cacheDir;
-  if (Platform.environment.containsKey('PUB_CACHE')) {
-    cacheDir = Platform.environment['PUB_CACHE'];
+  var pubCache = Platform.environment['PUB_CACHE'];
+  if (pubCache != null) {
+    cacheDir = pubCache;
   } else if (Platform.isWindows) {
     var appData = Platform.environment['APPDATA'];
     cacheDir = p.join(appData, 'Pub', 'Cache');

--- a/lib/src/standalone.dart
+++ b/lib/src/standalone.dart
@@ -275,7 +275,7 @@ Future<List<int>> _dartExecutable(String os, {@required bool x64}) async {
   return ZipDecoder()
       .decodeBytes(response.bodyBytes)
       .firstWhere((file) => file.name.endsWith(filename))
-      .content as List<int>;
+      .content as List<int>/*!*/;
 }
 
 /// Returns the architecture name for the given boolean.

--- a/lib/src/standalone.dart
+++ b/lib/src/standalone.dart
@@ -49,7 +49,7 @@ final standaloneName = InternalConfigVariable.fn<String>(() => name.value);
 /// to `build/${executable}.snapshot`.
 ///
 /// If [release] is `false`, this compiles with `--enable-asserts`.
-void _compileSnapshot({@required bool release}) {
+void _compileSnapshot({required bool release}) {
   ensureBuild();
   var existingSnapshots = <String, String>{};
   executables.value.forEach((name, path) {
@@ -163,7 +163,7 @@ void addStandaloneTasks() {
 /// We can only use the native executable on the current operating system *and*
 /// on 64-bit machines, because currently Dart doesn't support cross-compilation
 /// (dart-lang/sdk#28617) and only 64-bit Dart SDKs ship with `dart2aot`.
-bool _useNative(String os, {@required bool x64}) {
+bool _useNative(String os, {required bool x64}) {
   if (os != Platform.operatingSystem) return false;
   if (x64 != _is64Bit) return false;
 
@@ -193,7 +193,7 @@ Future<void> _buildDev() async {
 }
 
 /// Builds a package for the given [os] and architecture.
-Future<void> _buildPackage(String os, {@required bool x64}) async {
+Future<void> _buildPackage(String os, {required bool x64}) async {
   var archive = Archive()
     ..addFile(fileFromString("$standaloneName/src/LICENSE", await license));
 
@@ -235,18 +235,18 @@ Future<void> _buildPackage(String os, {@required bool x64}) async {
   if (os == 'windows') {
     var output = "$prefix.zip";
     log("Creating $output...");
-    File(output).writeAsBytesSync(ZipEncoder().encode(archive));
+    File(output).writeAsBytesSync(ZipEncoder().encode(archive)!);
   } else {
     var output = "$prefix.tar.gz";
     log("Creating $output...");
     File(output)
-        .writeAsBytesSync(GZipEncoder().encode(TarEncoder().encode(archive)));
+        .writeAsBytesSync(GZipEncoder().encode(TarEncoder().encode(archive))!);
   }
 }
 
 /// Returns the binary contents of the `dart` or `dartaotruntime` exectuable for
 /// the given [os] and architecture.
-Future<List<int>> _dartExecutable(String os, {@required bool x64}) async {
+Future<List<int>> _dartExecutable(String os, {required bool x64}) async {
   // If we're building for the same SDK we're using, load its executable from
   // disk rather than downloading it fresh.
   if (_useNative(os, x64: x64)) {
@@ -275,7 +275,7 @@ Future<List<int>> _dartExecutable(String os, {@required bool x64}) async {
   return ZipDecoder()
       .decodeBytes(response.bodyBytes)
       .firstWhere((file) => file.name.endsWith(filename))
-      .content as List<int>/*!*/;
+      .content as List<int>;
 }
 
 /// Returns the architecture name for the given boolean.

--- a/lib/src/standalone.dart
+++ b/lib/src/standalone.dart
@@ -18,7 +18,6 @@ import 'dart:io';
 
 import 'package:archive/archive.dart';
 import 'package:grinder/grinder.dart';
-import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 
 import 'config_variable.dart';

--- a/lib/src/template.dart
+++ b/lib/src/template.dart
@@ -15,20 +15,24 @@
 import 'dart:cli';
 import 'dart:io';
 
-import 'package:mustache/mustache.dart';
 import 'package:path/path.dart' as p;
 
 import 'utils.dart';
 
-/// A cache of parsed templates.
-final _cache = p.PathMap<Template>();
+/// A cache of template file contents.
+final _cache = p.PathMap<String>();
 
 /// Loads the template from [path] (relative to `lib/src/templates`, without the
 /// trailing `.mustache`) and renders it using [variables].
+///
+/// Note: This function only supports simple variable replacement. It does not
+/// support any additional Mustache features.
 String renderTemplate(String path, Map<String, String> variables) {
   path = p.join(waitFor(cliPkgSrc), 'templates', path);
-  return _cache
-      .putIfAbsent(path,
-          () => Template(File("$path.mustache").readAsStringSync(), name: path))
-      .renderString(variables);
+  var text =
+      _cache.putIfAbsent(path, () => File("$path.mustache").readAsStringSync());
+  for (var entry in variables.entries) {
+    text = text.replaceAll('{{{${entry.key}}}}', entry.value);
+  }
+  return text;
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -31,8 +31,8 @@ import 'info.dart';
 
 /// The raw YAML of the pubspec.
 final rawPubspec =
-    loadYaml(File('pubspec.yaml').readAsStringSync(), sourceUrl: 'pubspec.yaml')
-        as Map<Object, Object>;
+    loadYaml(File('pubspec.yaml').readAsStringSync(), sourceUrl: Uri(path: 'pubspec.yaml'))
+        as Map<Object, Object>/*!*/;
 
 /// The set of entrypoint paths for executables defined by this package.
 Set<String> get entrypoints => p.PathSet.of(executables.value.values);
@@ -97,6 +97,7 @@ Future<String> get license => _licenseMemo.runOnce(() async {
       // dependencies. This also includes dev dependencies, but it's possible those
       // are compiled into the distribution anyway (especially for stuff like
       // `node_preamble`).
+      // TODO: remove as
       var packageConfigUrl = await Isolate.packageConfig;
       var packageConfig = await loadPackageConfigUri(packageConfigUrl);
 
@@ -324,6 +325,7 @@ Future<String> cloneOrPull(String url) async {
 /// structure of lists and arrays of immutable scalar objects).
 Object freezeJson(Object object) {
   if (object is Map<String, Object>) return freezeJsonMap(object);
+  // TODO: remove as
   if (object is List) return List<Object>.unmodifiable(object.map(freezeJson));
   return object;
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -30,9 +30,8 @@ import 'package:yaml/yaml.dart';
 import 'info.dart';
 
 /// The raw YAML of the pubspec.
-final rawPubspec =
-    loadYaml(File('pubspec.yaml').readAsStringSync(), sourceUrl: Uri(path: 'pubspec.yaml'))
-        as Map<Object, Object>/*!*/;
+final rawPubspec = loadYaml(File('pubspec.yaml').readAsStringSync(),
+    sourceUrl: Uri(path: 'pubspec.yaml')) as Map<Object, Object> /*!*/;
 
 /// The set of entrypoint paths for executables defined by this package.
 Set<String> get entrypoints => p.PathSet.of(executables.value.values);

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -96,9 +96,8 @@ Future<String> get license => _licenseMemo.runOnce(() async {
       // dependencies. This also includes dev dependencies, but it's possible those
       // are compiled into the distribution anyway (especially for stuff like
       // `node_preamble`).
-      // TODO: remove as
-      var packageConfigUrl = await (Isolate.packageConfig as FutureOr<Uri>);
-      var packageConfig = await loadPackageConfigUri(packageConfigUrl);
+      var packageConfigUrl = await Isolate.packageConfig;
+      var packageConfig = await loadPackageConfigUri(packageConfigUrl!);
 
       // Sort the dependencies alphabetically to guarantee a consistent
       // ordering.

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -31,10 +31,10 @@ import 'info.dart';
 
 /// The raw YAML of the pubspec.
 final rawPubspec = loadYaml(File('pubspec.yaml').readAsStringSync(),
-    sourceUrl: Uri(path: 'pubspec.yaml')) as Map<Object, Object> /*!*/;
+    sourceUrl: Uri(path: 'pubspec.yaml')) as Map<Object, Object>;
 
 /// The set of entrypoint paths for executables defined by this package.
-Set<String> get entrypoints => p.PathSet.of(executables.value.values);
+Set<String?> get entrypoints => p.PathSet.of(executables.value.values);
 
 /// The version of the current Dart executable.
 final Version dartVersion = Version.parse(Platform.version.split(" ").first);
@@ -97,7 +97,7 @@ Future<String> get license => _licenseMemo.runOnce(() async {
       // are compiled into the distribution anyway (especially for stuff like
       // `node_preamble`).
       // TODO: remove as
-      var packageConfigUrl = await Isolate.packageConfig;
+      var packageConfigUrl = await (Isolate.packageConfig as FutureOr<Uri>);
       var packageConfig = await loadPackageConfigUri(packageConfigUrl);
 
       // Sort the dependencies alphabetically to guarantee a consistent
@@ -145,7 +145,7 @@ String _readSdkLicense() {
 
 /// Returns the contents of the `LICENSE` file in [dir], with various possible
 /// filenames and extensions, or `null`.
-String _readLicense(String dir) {
+String? _readLicense(String dir) {
   if (!Directory(dir).existsSync()) return null;
 
   var possibilities = Directory(dir)
@@ -227,7 +227,7 @@ String humanOSName(String os) {
 ///
 /// This converts each element of [iter] to a string and separates them with
 /// commas and/or [conjunction] (`"and"` by default) where appropriate.
-String toSentence(Iterable<Object> iter, {String conjunction}) {
+String toSentence(Iterable<Object> iter, {String? conjunction}) {
   if (iter.length == 1) return iter.first.toString();
   conjunction ??= 'and';
   return iter.take(iter.length - 1).join(", ") + " $conjunction ${iter.last}";
@@ -324,8 +324,9 @@ Future<String> cloneOrPull(String url) async {
 /// structure of lists and arrays of immutable scalar objects).
 Object freezeJson(Object object) {
   if (object is Map<String, Object>) return freezeJsonMap(object);
-  // TODO: remove as
-  if (object is List) return List<Object>.unmodifiable(object.map(freezeJson));
+  if (object is List<Object>) {
+    return List<Object>.unmodifiable(object.map(freezeJson));
+  }
   return object;
 }
 

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -31,7 +31,7 @@ import 'info.dart';
 
 /// The raw YAML of the pubspec.
 final rawPubspec = loadYaml(File('pubspec.yaml').readAsStringSync(),
-    sourceUrl: Uri(path: 'pubspec.yaml')) as Map<Object, Object>;
+    sourceUrl: Uri(path: 'pubspec.yaml')) as Map<dynamic, dynamic>;
 
 /// The set of entrypoint paths for executables defined by this package.
 Set<String?> get entrypoints => p.PathSet.of(executables.value.values);
@@ -226,7 +226,7 @@ String humanOSName(String os) {
 ///
 /// This converts each element of [iter] to a string and separates them with
 /// commas and/or [conjunction] (`"and"` by default) where appropriate.
-String toSentence(Iterable<Object> iter, {String? conjunction}) {
+String toSentence(Iterable<dynamic> iter, {String? conjunction}) {
   if (iter.length == 1) return iter.first.toString();
   conjunction ??= 'and';
   return iter.take(iter.length - 1).join(", ") + " $conjunction ${iter.last}";
@@ -321,15 +321,15 @@ Future<String> cloneOrPull(String url) async {
 
 /// Returns an unmodifiable copy of the JSON-compatible [object] (that is, a
 /// structure of lists and arrays of immutable scalar objects).
-Object freezeJson(Object object) {
-  if (object is Map<String, Object>) return freezeJsonMap(object);
-  if (object is List<Object>) {
-    return List<Object>.unmodifiable(object.map(freezeJson));
+dynamic freezeJson(dynamic object) {
+  if (object is Map<String, dynamic>) return freezeJsonMap(object);
+  if (object is List<dynamic>) {
+    return List<dynamic>.unmodifiable(object.map(freezeJson));
   }
   return object;
 }
 
 /// Like [freezeJson], but typed specifically for a map argument.
-Map<String, Object> freezeJsonMap(Map<String, Object> map) =>
+Map<String, dynamic> freezeJsonMap(Map<String, dynamic> map) =>
     UnmodifiableMapView(
         {for (var entry in map.entries) entry.key: freezeJson(entry.value)});

--- a/lib/testing.dart
+++ b/lib/testing.dart
@@ -54,12 +54,12 @@ final _hasPathDependency = _dependenciesHasPath(pubspec.dependencies) ||
 /// an out-of-date executable.
 Future<TestProcess> start(String executable, Iterable<String> arguments,
         {bool node = false,
-        String workingDirectory,
-        Map<String, String> environment,
+        String? workingDirectory,
+        Map<String, String>? environment,
         bool includeParentEnvironment = true,
         bool runInShell = false,
-        String description,
-        Encoding encoding,
+        String? description,
+        required Encoding encoding,
         bool forwardStdio = false}) async =>
     await TestProcess.start(executableRunner(executable, node: node),
         [...executableArgs(executable, node: node), ...arguments],
@@ -193,7 +193,7 @@ void ensureExecutableUpToDate(String executable, {bool node = false}) {
 /// If [path] doesn't exist or is out of date, throws a [TestFailure]
 /// encouraging the user to run [commandToRun].
 void ensureUpToDate(String path, String commandToRun,
-    {Iterable<String> dependencies}) {
+    {Iterable<String?>? dependencies}) {
   // Ensure path is relative so the error messages are more readable.
   path = p.relative(path);
   if (!File(path).existsSync()) {
@@ -202,7 +202,7 @@ void ensureUpToDate(String path, String commandToRun,
 
   var entriesToCheck = [
     for (var dependency in [...?dependencies, "lib"])
-      if (Directory(dependency).existsSync())
+      if (Directory(dependency!).existsSync())
         ...Directory(dependency).listSync(recursive: true)
       else if (File(dependency).existsSync())
         File(dependency),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,33 +7,62 @@ environment:
   sdk: '>=2.7.0 <3.0.0'
 
 dependencies:
-  archive: ">=1.0.0 <3.0.0"
-  async: '>=1.13.0 <3.0.0'
-  charcode: "^1.1.0"
-  collection: ">=1.8.0 <2.0.0"
-  crypto: "^2.0.0"
-  grinder: '^0.8.6'
-  http: ">=0.11.0 <0.13.0"
-  js: "^0.6.0"
-  meta: "^1.1.7"
-  mustache: "^1.0.0"
+  archive: ^3.0.0-nullsafety
+  async: ^2.5.0-nullsafety
+  charcode: ^1.2.0-nullsafety
+  collection: ^1.15.0-nullsafety
+  crypto: ^2.2.0-nullsafety
+  grinder: ^0.8.7-nullsafety
+  http: ^0.13.0-nullsafety
+  js: ^0.6.3-nullsafety
+  meta: ^1.3.0-nullsafety
+  mustache: ^1.2.0-nullsafety
   node_interop: "^1.1.0"
-  node_preamble: "^1.1.0"
-  package_config: '^1.9.0'
-  path: '^1.0.0'
-  pub_semver: '^1.0.0'
+  node_preamble: ^1.14.13-nullsafety
+  package_config: ^2.0.0
+  path: ^1.8.0-nullsafety
+  pub_semver: ^2.0.0-nullsafety
   pubspec_parse: '^0.1.0'
   string_scanner: '^1.0.0'
-  test: '^1.0.0'
-  test_process: '^1.0.0'
-  xml: '^4.2.0'
-  yaml: '^2.0.0'
+  test: ^1.16.0-nullsafety
+  test_process: ^1.1.0-nullsafety
+  xml: ^5.0.0-nullsafety
+  yaml: ^3.0.0-nullsafety
 
 dev_dependencies:
-  pedantic: '^1.6.0'
+  pedantic: ^1.10.0-nullsafety
   sass_analysis:
     git: {url: git://github.com/sass/dart-sass, path: analysis}
-  shelf: '^0.7.0'
+  shelf: ^1.0.0-nullsafety
   shelf_test_handler: '^1.0.0'
-  test_descriptor: '^1.2.0'
-  tuple: '^1.0.0'
+  test_descriptor: ^2.0.0-nullsafety
+  tuple: ^2.0.0-nullsafety
+
+dependency_overrides:
+  archive:
+    git: {url: git://github.com/brendan-duncan/archive}
+  crypto:
+    git: {url: git://github.com/dart-lang/crypto}
+  grinder:
+    git: {url: git://github.com/nex3/grinder.dart, ref: nnbd}
+  http:
+    git: {url: git://github.com/dart-lang/http}
+  mustache:
+    git: {url: git://github.com/nex3/mustache, ref: nnbd}
+  node_preamble:
+    git: {url: git://github.com/mbullington/node_preamble.dart}
+  package_config:
+    git: {url: git://github.com/dart-lang/package_config}
+  path:
+    git: {url: git://github.com/dart-lang/path, ref: path-set-null}
+  shelf:
+    git: {url: git://github.com/dart-lang/shelf}
+  tuple:
+    git: {url: git://github.com/google/tuple.dart}
+  test_process:
+    git: {url: git://github.com/jathak/test_process, ref: null-safety}
+  convert: ^3.0.0-nullsafety
+  glob: ^2.0.0-nullsafety
+  http_parser: ^4.0.0-nullsafety
+  pub_semver: ^2.0.0-nullsafety
+  yaml: ^3.0.0-nullsafety

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,62 +7,40 @@ environment:
   sdk: '>=2.7.0 <3.0.0'
 
 dependencies:
-  archive: ^3.0.0-nullsafety
-  async: ^2.5.0-nullsafety
-  charcode: ^1.2.0-nullsafety
-  collection: ^1.15.0-nullsafety
-  crypto: ^2.2.0-nullsafety
-  grinder: ^0.8.7-nullsafety
-  http: ^0.13.0-nullsafety
-  js: ^0.6.3-nullsafety
-  meta: ^1.3.0-nullsafety
-  mustache: ^1.2.0-nullsafety
-  node_interop: "^1.1.0"
-  node_preamble: ^1.14.13-nullsafety
+  archive: ^3.1.2
+  async: ^2.5.0
+  charcode: ^1.2.0
+  collection: ^1.15.0
+  crypto: ^3.0.0
+  grinder: ^0.9.0-nullsafety.0
+  http: ^0.13.0
+  js: ^0.6.3
+  meta: ^1.3.0
+  mustache: #"^1.2.0"
+    git: {url: git://github.com/nex3/mustache, ref: nnbd}
+  node_interop: #"^2.0.0"
+    git:
+      url: git://github.com/Awjin/node-interop
+      path: node_interop
+      ref: null-safe-interop
+  node_preamble: ^2.0.0
   package_config: ^2.0.0
-  path: ^1.8.0-nullsafety
-  pub_semver: ^2.0.0-nullsafety
-  pubspec_parse: '^0.1.0'
-  string_scanner: '^1.0.0'
-  test: ^1.16.0-nullsafety
-  test_process: ^1.1.0-nullsafety
-  xml: ^5.0.0-nullsafety
-  yaml: ^3.0.0-nullsafety
+  path: ^1.8.0
+  pub_semver: ^2.0.0
+  pubspec_parse: ^1.0.0
+  string_scanner: ^1.1.0
+  test: ^1.16.6
+  test_process: ^2.0.0
+  xml: ^5.0.2
+  yaml: ^3.1.0
+
+publish_to: none
 
 dev_dependencies:
-  pedantic: ^1.10.0-nullsafety
+  pedantic: ^1.11.0
   sass_analysis:
     git: {url: git://github.com/sass/dart-sass, path: analysis}
-  shelf: ^1.0.0-nullsafety
-  shelf_test_handler: '^1.0.0'
-  test_descriptor: ^2.0.0-nullsafety
-  tuple: ^2.0.0-nullsafety
-
-dependency_overrides:
-  archive:
-    git: {url: git://github.com/brendan-duncan/archive}
-  crypto:
-    git: {url: git://github.com/dart-lang/crypto}
-  grinder:
-    git: {url: git://github.com/nex3/grinder.dart, ref: nnbd}
-  http:
-    git: {url: git://github.com/dart-lang/http}
-  mustache:
-    git: {url: git://github.com/nex3/mustache, ref: nnbd}
-  node_preamble:
-    git: {url: git://github.com/mbullington/node_preamble.dart}
-  package_config:
-    git: {url: git://github.com/dart-lang/package_config}
-  path:
-    git: {url: git://github.com/dart-lang/path, ref: path-set-null}
-  shelf:
-    git: {url: git://github.com/dart-lang/shelf}
-  tuple:
-    git: {url: git://github.com/google/tuple.dart}
-  test_process:
-    git: {url: git://github.com/jathak/test_process, ref: null-safety}
-  convert: ^3.0.0-nullsafety
-  glob: ^2.0.0-nullsafety
-  http_parser: ^4.0.0-nullsafety
-  pub_semver: ^2.0.0-nullsafety
-  yaml: ^3.0.0-nullsafety
+  shelf: ^1.0.0
+  shelf_test_handler: ^2.0.0
+  test_descriptor: ^2.0.0
+  tuple: ^2.0.0-nullsafety.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,14 +12,11 @@ dependencies:
   charcode: ^1.2.0
   collection: ^1.15.0
   crypto: ^3.0.0
-  grinder: ^0.9.0-nullsafety.0
+  grinder: ^0.9.0
   http: ^0.13.0
   js: ^0.6.3
   meta: ^1.3.0
-  node_interop: #"^2.0.0"
-    git:
-      url: git://github.com/pulyaevskiy/node-interop
-      path: node_interop
+  node_interop: ^2.0.0
   node_preamble: ^2.0.0
   package_config: ^2.0.0
   path: ^1.8.0
@@ -30,8 +27,6 @@ dependencies:
   test_process: ^2.0.0
   xml: ^5.0.2
   yaml: ^3.1.0
-
-publish_to: none
 
 dev_dependencies:
   pedantic: ^1.11.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,9 +18,8 @@ dependencies:
   meta: ^1.3.0
   node_interop: #"^2.0.0"
     git:
-      url: git://github.com/Awjin/node-interop
+      url: git://github.com/pulyaevskiy/node-interop
       path: node_interop
-      ref: null-safe-interop
   node_preamble: ^2.0.0
   package_config: ^2.0.0
   path: ^1.8.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_pkg
-version: 1.2.0
+version: 1.3.0
 description: Grinder tasks for releasing Dart CLI packages.
 homepage: https://github.com/google/dart_cli_pkg
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Grinder tasks for releasing Dart CLI packages.
 homepage: https://github.com/google/dart_cli_pkg
 
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   archive: ^3.1.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,8 +16,6 @@ dependencies:
   http: ^0.13.0
   js: ^0.6.3
   meta: ^1.3.0
-  mustache: #"^1.2.0"
-    git: {url: git://github.com/nex3/mustache, ref: nnbd}
   node_interop: #"^2.0.0"
     git:
       url: git://github.com/Awjin/node-interop

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   pub_semver: ^2.0.0
   pubspec_parse: ^1.0.0
   string_scanner: ^1.1.0
-  test: ^1.16.6
+  test: ^1.16.7
   test_process: ^2.0.0
   xml: ^5.0.2
   yaml: ^3.1.0

--- a/test/chocolatey_test.dart
+++ b/test/chocolatey_test.dart
@@ -318,7 +318,7 @@ String _enableChocolatey({bool token = true}) {
 ///
 /// If [extraMetadata] is passed, it's added to the nuspec's `<metadata>`tag.
 
-d.FileDescriptor _nuspec([String extraMetadata]) {
+d.FileDescriptor _nuspec([String? extraMetadata]) {
   return d.file("my_app_choco.nuspec", """
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
@@ -334,7 +334,7 @@ d.FileDescriptor _nuspec([String extraMetadata]) {
 
 /// A [Matcher] that asserts that a string has the same XML structure as
 /// [expected], ignoring whitespace.
-Matcher _equalsXml(String expected) => predicate((actual) {
+Matcher _equalsXml(String expected) => predicate((dynamic actual) {
       expect(actual, isA<String>());
       expect(XmlDocument.parse(actual as String).toXmlString(pretty: true),
           equals(XmlDocument.parse(expected).toXmlString(pretty: true)));

--- a/test/config_variable_test.dart
+++ b/test/config_variable_test.dart
@@ -158,6 +158,7 @@ void main() {
     group("the freeze function", () {
       test("isn't called if ConfigVariable.freeze() isn't", () {
         var variable = InternalConfigVariable.value(1,
+            // TODO: no dynamic
             freeze: expectAsync1((n) => 0, count: 0));
         expect(variable.value, equals(1));
       });

--- a/test/config_variable_test.dart
+++ b/test/config_variable_test.dart
@@ -105,19 +105,19 @@ void main() {
 
     test("isn't called if the value isn't accessed", () {
       var variable = InternalConfigVariable.value(1);
-      variable.fn = expectAsync0(() => null, count: 0);
+      variable.fn = expectAsync0(() => 0, count: 0);
     });
 
     test("isn't called if the value is overridden", () {
       var variable = InternalConfigVariable.value(1);
-      variable.fn = expectAsync0(() => null, count: 0);
+      variable.fn = expectAsync0(() => 0, count: 0);
       variable.value = 12;
       expect(variable.value, equals(12));
     });
 
     test("isn't called if the function is overridden", () {
       var variable = InternalConfigVariable.value(1);
-      variable.fn = expectAsync0(() => null, count: 0);
+      variable.fn = expectAsync0(() => 0, count: 0);
       variable.fn = () => 12;
       expect(variable.value, equals(12));
     });
@@ -158,19 +158,19 @@ void main() {
     group("the freeze function", () {
       test("isn't called if ConfigVariable.freeze() isn't", () {
         var variable = InternalConfigVariable.value(1,
-            // TODO: no dynamic
-            freeze: expectAsync1((dynamic n) => 0, count: 0));
+            freeze: expectAsync1((n) => 0, count: 0));
         expect(variable.value, equals(1));
       });
 
       test("modifies a cached value", () {
-        var variable = InternalConfigVariable.value(1, freeze: (n) => n + 1);
+        var variable =
+            InternalConfigVariable.value<int>(1, freeze: (n) => n + 1);
         variable.freeze();
         expect(variable.value, equals(2));
       });
 
       test("is only called once", () {
-        var variable = InternalConfigVariable.value(1,
+        var variable = InternalConfigVariable.value<int>(1,
             freeze: expectAsync1((n) => n + 1, count: 1));
         variable.freeze();
         variable.freeze();
@@ -178,13 +178,14 @@ void main() {
       });
 
       test("modifies a function's return value", () {
-        var variable = InternalConfigVariable.fn(() => 1, freeze: (n) => n + 1);
+        var variable =
+            InternalConfigVariable.fn<int>(() => 1, freeze: (n) => n + 1);
         variable.freeze();
         expect(variable.value, equals(2));
       });
 
       test("is only called once", () {
-        var variable = InternalConfigVariable.fn(
+        var variable = InternalConfigVariable.fn<int>(
             expectAsync0(() => 1, count: 1),
             freeze: expectAsync1((n) => n + 1, count: 1));
         variable.freeze();

--- a/test/config_variable_test.dart
+++ b/test/config_variable_test.dart
@@ -62,14 +62,14 @@ void main() {
 
     test("isn't called if the value is overridden", () {
       var variable =
-          InternalConfigVariable.fn<int>(expectAsync0(() => null, count: 0));
+          InternalConfigVariable.fn<int?>(expectAsync0(() => null, count: 0));
       variable.value = 12;
       expect(variable.value, equals(12));
     });
 
     test("isn't called if the function is overridden", () {
       var variable =
-          InternalConfigVariable.fn<int>(expectAsync0(() => null, count: 0));
+          InternalConfigVariable.fn<int?>(expectAsync0(() => null, count: 0));
       variable.fn = () => 12;
       expect(variable.value, equals(12));
     });
@@ -159,7 +159,7 @@ void main() {
       test("isn't called if ConfigVariable.freeze() isn't", () {
         var variable = InternalConfigVariable.value(1,
             // TODO: no dynamic
-            freeze: expectAsync1((n) => 0, count: 0));
+            freeze: expectAsync1((dynamic n) => 0, count: 0));
         expect(variable.value, equals(1));
       });
 

--- a/test/descriptor.dart
+++ b/test/descriptor.dart
@@ -16,20 +16,19 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
-import 'package:test_descriptor/test_descriptor.dart' hide ArchiveDescriptor;
+import 'package:test_descriptor/test_descriptor.dart';
 import 'package:yaml/yaml.dart';
 
 import 'descriptor/archive.dart';
 import 'utils.dart';
 
-export 'package:test_descriptor/test_descriptor.dart'
-    hide archive, ArchiveDescriptor;
+export 'package:test_descriptor/test_descriptor.dart';
 
 export 'descriptor/archive.dart';
 
 /// The `cli_pkg` package's pubpsec.
 final _ourPubpsec = loadYaml(File('pubspec.yaml').readAsStringSync(),
-    sourceUrl: 'pubspec.yaml');
+    sourceUrl: Uri(path: 'pubspec.yaml'));
 
 /// Returns a directory descriptor for a package in [appDir] with the given
 /// pubspec and `grind.dart` file, as well as other optional files.
@@ -42,7 +41,7 @@ final _ourPubpsec = loadYaml(File('pubspec.yaml').readAsStringSync(),
 /// * Adds a dependency on grinder and `cli_pkg`.
 ///
 /// * Imports `package:grinder/grinder.dart` and `package:cli_pkg/cli_pkg.dart`.
-DirectoryDescriptor package(Map<String, Object> pubspec, String grindDotDart,
+DirectoryDescriptor package(Map<String, Object/*!*/> pubspec, String grindDotDart,
     [List<Descriptor> files]) {
   pubspec = {
     "environment": _ourPubpsec["environment"],
@@ -96,16 +95,18 @@ DirectoryDescriptor package(Map<String, Object> pubspec, String grindDotDart,
 
 /// Returns the dependency description for `package` from `cli_pkg`'s own
 /// pubspec, as a map so it can be included in a map literal with `...`.
-Map<String, Object> _ourDependency(String package) =>
+Map<String, Object/*!*/> _ourDependency(String package) =>
     {package: _ourPubpsec["dependencies"][package]};
 
 /// Returns the dependency override for `package` from `cli_pkg`'s own pubspec,
 /// as a map so it can be included in a map literal with `...?`.
-Map<String, Object> _ourDependencyOverride(String package) {
-  var overrides = (_ourPubpsec["dependency_overrides"] as YamlMap);
-  return overrides != null && overrides.containsKey(package)
-      ? {package: overrides[package]}
-      : const {};
+Map<String, Object/*!*/> _ourDependencyOverride(String package) {
+  var overrides = _ourPubpsec["dependency_overrides"];
+  if (overrides == null) return const {};
+
+  // TODO: use ?[]
+  var descriptor = (overrides as YamlMap)[package];
+  return descriptor == null ? const {} : {package: overrides[package]};
 }
 
 /// Creates a new [ArchiveDescriptor] with [name] and [contents].

--- a/test/descriptor.dart
+++ b/test/descriptor.dart
@@ -41,17 +41,17 @@ final _ourPubspec = loadYaml(File('pubspec.yaml').readAsStringSync(),
 /// * Adds a dependency on grinder and `cli_pkg`.
 ///
 /// * Imports `package:grinder/grinder.dart` and `package:cli_pkg/cli_pkg.dart`.
-DirectoryDescriptor package(Map<String, Object> pubspec, String grindDotDart,
+DirectoryDescriptor package(Map<String, dynamic> pubspec, String grindDotDart,
     [List<Descriptor>? files]) {
   pubspec = {
-    "environment": _ourPubspec["environment"] as Object,
-    "executables": <String, Object>{},
+    "environment": _ourPubspec["environment"],
+    "executables": <String, dynamic>{},
     ...pubspec,
     "dev_dependencies": {
       ..._ourDependency("grinder"),
       ..._ourDependency("test"),
       "cli_pkg": {"path": p.current},
-      ...?(pubspec["dev_dependencies"] as Map<String, Object>?),
+      ...?(pubspec["dev_dependencies"] as Map<String, dynamic>?),
     },
     "dependency_overrides": {
       ..._ourDependencyOverride("grinder"),
@@ -60,8 +60,8 @@ DirectoryDescriptor package(Map<String, Object> pubspec, String grindDotDart,
   };
 
   var executables = pubspec.containsKey("executables")
-      ? (pubspec["executables"] as Map<String, Object>).values.toSet()
-      : const <Object>{};
+      ? (pubspec["executables"] as Map<String, dynamic>).values.toSet()
+      : const <dynamic>{};
 
   return dir(p.basename(appDir), [
     file("pubspec.yaml", json.encode(pubspec)),
@@ -95,13 +95,13 @@ DirectoryDescriptor package(Map<String, Object> pubspec, String grindDotDart,
 
 /// Returns the dependency description for `package` from `cli_pkg`'s own
 /// pubspec, as a map so it can be included in a map literal with `...`.
-Map<String, Object> _ourDependency(String package) =>
-    {package: _ourPubspec["dependencies"][package] as Object};
+Map<String, dynamic> _ourDependency(String package) =>
+    {package: _ourPubspec["dependencies"][package]};
 
 /// Returns the dependency override for `package` from `cli_pkg`'s own pubspec,
 /// as a map so it can be included in a map literal with `...?`.
-Map<String, Object> _ourDependencyOverride(String package) {
-  var descriptor = _ourPubspec["dependency_overrides"]?[package] as Object?;
+Map<String, dynamic> _ourDependencyOverride(String package) {
+  var descriptor = _ourPubspec["dependency_overrides"]?[package];
   return descriptor == null ? const {} : {package: descriptor};
 }
 

--- a/test/descriptor.dart
+++ b/test/descriptor.dart
@@ -41,11 +41,10 @@ final _ourPubspec = loadYaml(File('pubspec.yaml').readAsStringSync(),
 /// * Adds a dependency on grinder and `cli_pkg`.
 ///
 /// * Imports `package:grinder/grinder.dart` and `package:cli_pkg/cli_pkg.dart`.
-DirectoryDescriptor package(
-    Map<String, Object > pubspec, String grindDotDart,
+DirectoryDescriptor package(Map<String, Object> pubspec, String grindDotDart,
     [List<Descriptor>? files]) {
   pubspec = {
-    "environment": _ourPubspec["environment"],
+    "environment": _ourPubspec["environment"] as Object,
     "executables": <String, Object>{},
     ...pubspec,
     "dev_dependencies": {
@@ -55,8 +54,8 @@ DirectoryDescriptor package(
       ...?(pubspec["dev_dependencies"] as Map<String, Object>?),
     },
     "dependency_overrides": {
-      ...?_ourDependencyOverride("grinder"),
-      ...?_ourDependencyOverride("test"),
+      ..._ourDependencyOverride("grinder"),
+      ..._ourDependencyOverride("test"),
     },
   };
 
@@ -96,18 +95,14 @@ DirectoryDescriptor package(
 
 /// Returns the dependency description for `package` from `cli_pkg`'s own
 /// pubspec, as a map so it can be included in a map literal with `...`.
-Map<String, Object > _ourDependency(String package) =>
-    {package: _ourPubspec["dependencies"][package]};
+Map<String, Object> _ourDependency(String package) =>
+    {package: _ourPubspec["dependencies"][package] as Object};
 
 /// Returns the dependency override for `package` from `cli_pkg`'s own pubspec,
 /// as a map so it can be included in a map literal with `...?`.
-Map<String, Object > _ourDependencyOverride(String package) {
-  var overrides = _ourPubspec["dependency_overrides"];
-  if (overrides == null) return const {};
-
-  // TODO: use ?[]
-  var descriptor = (overrides as YamlMap)[package];
-  return descriptor == null ? const {} : {package: overrides[package]};
+Map<String, Object> _ourDependencyOverride(String package) {
+  var descriptor = _ourPubspec["dependency_overrides"]?[package] as Object?;
+  return descriptor == null ? const {} : {package: descriptor};
 }
 
 /// Creates a new [ArchiveDescriptor] with [name] and [contents].

--- a/test/descriptor.dart
+++ b/test/descriptor.dart
@@ -27,7 +27,7 @@ export 'package:test_descriptor/test_descriptor.dart';
 export 'descriptor/archive.dart';
 
 /// The `cli_pkg` package's pubpsec.
-final _ourPubpsec = loadYaml(File('pubspec.yaml').readAsStringSync(),
+final _ourPubspec = loadYaml(File('pubspec.yaml').readAsStringSync(),
     sourceUrl: Uri(path: 'pubspec.yaml'));
 
 /// Returns a directory descriptor for a package in [appDir] with the given
@@ -41,17 +41,18 @@ final _ourPubpsec = loadYaml(File('pubspec.yaml').readAsStringSync(),
 /// * Adds a dependency on grinder and `cli_pkg`.
 ///
 /// * Imports `package:grinder/grinder.dart` and `package:cli_pkg/cli_pkg.dart`.
-DirectoryDescriptor package(Map<String, Object/*!*/> pubspec, String grindDotDart,
-    [List<Descriptor> files]) {
+DirectoryDescriptor package(
+    Map<String, Object > pubspec, String grindDotDart,
+    [List<Descriptor>? files]) {
   pubspec = {
-    "environment": _ourPubpsec["environment"],
+    "environment": _ourPubspec["environment"],
     "executables": <String, Object>{},
     ...pubspec,
     "dev_dependencies": {
       ..._ourDependency("grinder"),
       ..._ourDependency("test"),
       "cli_pkg": {"path": p.current},
-      ...?(pubspec["dev_dependencies"] as Map<String, Object>),
+      ...?(pubspec["dev_dependencies"] as Map<String, Object>?),
     },
     "dependency_overrides": {
       ...?_ourDependencyOverride("grinder"),
@@ -95,13 +96,13 @@ DirectoryDescriptor package(Map<String, Object/*!*/> pubspec, String grindDotDar
 
 /// Returns the dependency description for `package` from `cli_pkg`'s own
 /// pubspec, as a map so it can be included in a map literal with `...`.
-Map<String, Object/*!*/> _ourDependency(String package) =>
-    {package: _ourPubpsec["dependencies"][package]};
+Map<String, Object > _ourDependency(String package) =>
+    {package: _ourPubspec["dependencies"][package]};
 
 /// Returns the dependency override for `package` from `cli_pkg`'s own pubspec,
 /// as a map so it can be included in a map literal with `...?`.
-Map<String, Object/*!*/> _ourDependencyOverride(String package) {
-  var overrides = _ourPubpsec["dependency_overrides"];
+Map<String, Object > _ourDependencyOverride(String package) {
+  var overrides = _ourPubspec["dependency_overrides"];
   if (overrides == null) return const {};
 
   // TODO: use ?[]

--- a/test/descriptor/archive.dart
+++ b/test/descriptor/archive.dart
@@ -44,7 +44,7 @@ class ArchiveDescriptor extends Descriptor implements FileDescriptor {
   ///
   /// If [parent] is passed, it's used as the parent directory for filenames.
   Future<Iterable<ArchiveFile>> _files(Iterable<Descriptor> descriptors,
-      [String parent]) async {
+      [String? parent]) async {
     return (await waitAndReportErrors(descriptors.map((descriptor) async {
       var fullName =
           parent == null ? descriptor.name : '$parent/${descriptor.name}';
@@ -73,7 +73,7 @@ class ArchiveDescriptor extends Descriptor implements FileDescriptor {
       : contents = List.unmodifiable(contents),
         super(name);
 
-  Future<void> create([String parent]) async {
+  Future<void> create([String? parent]) async {
     var path = p.join(parent ?? sandbox, name);
     var file = File(path).openWrite();
     try {
@@ -96,7 +96,7 @@ class ArchiveDescriptor extends Descriptor implements FileDescriptor {
         return _encodeFunction()(await archive);
       }());
 
-  Future<void> validate([String parent]) async {
+  Future<void> validate([String? parent]) async {
     // Access this first so we eaerly throw an error for a path with an invalid
     // extension.
     var decoder = _decodeFunction();
@@ -108,7 +108,7 @@ class ArchiveDescriptor extends Descriptor implements FileDescriptor {
     }
 
     var bytes = await File(fullPath).readAsBytes();
-    Archive archive;
+    late Archive archive;
     try {
       archive = decoder(bytes);
     } catch (_) {
@@ -145,15 +145,15 @@ class ArchiveDescriptor extends Descriptor implements FileDescriptor {
 
   /// Returns the function to use to encode this file to binary, based on its
   /// [name].
-  List<int>/*!*/ Function(Archive) _encodeFunction() {
+  List<int> Function(Archive) _encodeFunction() {
     if (name.endsWith('.zip')) {
-      return (archive) => ZipEncoder().encode(archive)/*!*/;
+      return (archive) => ZipEncoder().encode(archive)!;
     } else if (name.endsWith('.tar')) {
       return TarEncoder().encode;
     } else if (name.endsWith('.tar.gz') ||
         name.endsWith('.tar.gzip') ||
         name.endsWith('.tgz')) {
-      return (archive) => GZipEncoder().encode(TarEncoder().encode(archive));
+      return (archive) => GZipEncoder().encode(TarEncoder().encode(archive))!;
     } else if (name.endsWith('.tar.bz2') || name.endsWith('.tar.bzip2')) {
       return (archive) => BZip2Encoder().encode(TarEncoder().encode(archive));
     } else {

--- a/test/descriptor/archive.dart
+++ b/test/descriptor/archive.dart
@@ -145,9 +145,9 @@ class ArchiveDescriptor extends Descriptor implements FileDescriptor {
 
   /// Returns the function to use to encode this file to binary, based on its
   /// [name].
-  List<int> Function(Archive) _encodeFunction() {
+  List<int>/*!*/ Function(Archive) _encodeFunction() {
     if (name.endsWith('.zip')) {
-      return ZipEncoder().encode;
+      return (archive) => ZipEncoder().encode(archive)/*!*/;
     } else if (name.endsWith('.tar')) {
       return TarEncoder().encode;
     } else if (name.endsWith('.tar.gz') ||

--- a/test/descriptor/archive.dart
+++ b/test/descriptor/archive.dart
@@ -135,7 +135,7 @@ class ArchiveDescriptor extends Descriptor implements FileDescriptor {
         } on TestFailure catch (error) {
           // Replace the temporary directory with the path to the archive to
           // make the error more user-friendly.
-          fail(error.message.replaceAll(tempDir, pretty));
+          fail(error.message?.replaceAll(tempDir, pretty) ?? '');
         }
       }));
     } finally {

--- a/test/github_test.dart
+++ b/test/github_test.dart
@@ -180,7 +180,7 @@ void main() {
 
   group("username", () {
     Future<void> assertUsername(String expected,
-        {Map<String, String> environment}) async {
+        {Map<String, String>? environment}) async {
       await _release("my_org/my_app", verify: (request) {
         expect(_getAuthorization(request).item1, equals(expected));
       }, environment: environment);
@@ -212,7 +212,7 @@ void main() {
 
   group("password", () {
     Future<void> assertPassword(String expected,
-        {Map<String, String> environment}) async {
+        {Map<String, String>? environment}) async {
       await _release("my_org/my_app", verify: (request) {
         expect(_getAuthorization(request).item2, equals(expected));
       }, environment: environment);
@@ -258,10 +258,10 @@ void main() {
 
   group("bearer token", () {
     Future<void> assertToken(String expected,
-        {Map<String, String> environment}) async {
+        {Map<String, String>? environment}) async {
       await _release("my_org/my_app", verify: (request) {
         expect(request.headers, contains("authorization"));
-        var authorization = request.headers["authorization"];
+        var authorization = request.headers["authorization"]!;
         expect(authorization, startsWith("Bearer "));
 
         expect(authorization.substring("Bearer ".length), equals(expected));
@@ -302,7 +302,7 @@ void main() {
   group("release notes", () {
     Future<void> assertReleaseNotes(Object matcher) async {
       await _release("my_org/my_app", verify: (request) async {
-        expect(json.decode(await request.readAsString())["body"] as String,
+        expect(json.decode(await request.readAsString())["body"] as String?,
             matcher);
       });
     }
@@ -488,8 +488,8 @@ String _enableGithub(
 /// given [repo], passes that POST request to [verify], and returns a 201
 /// CREATED response.
 Future<void> _release(String repo,
-    {FutureOr<void> verify(shelf.Request request),
-    Map<String, String> environment}) async {
+    {FutureOr<void> verify(shelf.Request request)?,
+    Map<String, String>? environment}) async {
   var server = await ShelfTestServer.create();
   server.handler.expect("POST", "/repos/$repo/releases",
       expectAsync1((request) async {
@@ -568,7 +568,7 @@ Future<ShelfTestServer> _assertUploadsPackage(String os) async {
 /// authentication header.
 Tuple2<String, String> _getAuthorization(shelf.Request request) {
   expect(request.headers, contains("authorization"));
-  var authorization = request.headers["authorization"];
+  var authorization = request.headers["authorization"]!;
   expect(authorization, startsWith("Basic "));
 
   var decoded =

--- a/test/homebrew_test.dart
+++ b/test/homebrew_test.dart
@@ -378,7 +378,7 @@ void main() {
 /// If [config] is passed, it's injected as code in `main()`.
 ///
 /// If [repo] is `false`, this won't set `pkg.homebrewRepo`.
-String _enableHomebrew({String config, bool repo = true}) => """
+String _enableHomebrew({String? config, bool repo = true}) => """
   void main(List<String> args) {
     ${config ?? ''}
     ${repo ? 'pkg.homebrewRepo.value = "me/homebrew";' : ''}
@@ -436,7 +436,7 @@ Future<TestProcess> _homebrewUpdate() => grind([
 ///
 /// The [path] is the basename of the formula file to verify. If it isn't
 /// passed, it defaults to `my_app.rb`.
-Future<void> _assertFormula(Object matcher, {String path}) async {
+Future<void> _assertFormula(Object matcher, {String? path}) async {
   await git(["reset", "--hard", "HEAD"], workingDirectory: "me/homebrew.git");
   await d
       .file(p.join("me/homebrew.git", path ?? "my_app.rb"), matcher)

--- a/test/npm_test.dart
+++ b/test/npm_test.dart
@@ -75,6 +75,7 @@ void main() {
               "my_app/build/my_app.dart.js",
               allOf([
                 contains('self.fs = require("fs");'),
+                // TODO: no dynamic
                 predicate((string) =>
                     RegExp(r'require\("fs"\);')
                         .allMatches(string as String)

--- a/test/npm_test.dart
+++ b/test/npm_test.dart
@@ -75,8 +75,7 @@ void main() {
               "my_app/build/my_app.dart.js",
               allOf([
                 contains('self.fs = require("fs");'),
-                // TODO: no dynamic
-                predicate((dynamic string) =>
+                predicate((string) =>
                     RegExp(r'require\("fs"\);')
                         .allMatches(string as String)
                         .length ==
@@ -401,7 +400,7 @@ void main() {
       """, [_packageJson]).create();
 
       var grinder = await grind(["pkg-npm-dev"]);
-      await expect(grinder.stdout, emitsThrough("latest"));
+      await expectLater(grinder.stdout, emitsThrough("latest"));
       await grinder.shouldExit();
     });
 
@@ -413,7 +412,7 @@ void main() {
       """, [_packageJson]).create();
 
       var grinder = await grind(["pkg-npm-dev"]);
-      await expect(grinder.stdout, emitsThrough("foo"));
+      await expectLater(grinder.stdout, emitsThrough("foo"));
       await grinder.shouldExit();
     });
 
@@ -425,7 +424,7 @@ void main() {
       """, [_packageJson]).create();
 
       var grinder = await grind(["pkg-npm-dev"]);
-      await expect(grinder.stdout, emitsThrough("pre"));
+      await expectLater(grinder.stdout, emitsThrough("pre"));
       await grinder.shouldExit();
     });
 
@@ -438,7 +437,7 @@ void main() {
       """, [_packageJson]).create();
 
       var grinder = await grind(["pkg-npm-dev"]);
-      await expect(grinder.stdout, emitsThrough("qux"));
+      await expectLater(grinder.stdout, emitsThrough("qux"));
       await grinder.shouldExit();
     });
   });

--- a/test/npm_test.dart
+++ b/test/npm_test.dart
@@ -76,7 +76,7 @@ void main() {
               allOf([
                 contains('self.fs = require("fs");'),
                 // TODO: no dynamic
-                predicate((string) =>
+                predicate((dynamic string) =>
                     RegExp(r'require\("fs"\);')
                         .allMatches(string as String)
                         .length ==

--- a/test/standalone_test.dart
+++ b/test/standalone_test.dart
@@ -15,7 +15,6 @@
 import 'dart:io';
 import 'dart:convert';
 
-import 'package:meta/meta.dart';
 import 'package:test/test.dart';
 import 'package:test_process/test_process.dart';
 

--- a/test/standalone_test.dart
+++ b/test/standalone_test.dart
@@ -295,7 +295,7 @@ void main() {
           "executables": {"foo": "foo"}
         }, _enableStandalone).create());
 
-    d.Descriptor archive(String os, {@required bool x64}) {
+    d.Descriptor archive(String os, {required bool x64}) {
       var name = "my_app/build/my_app-1.2.3-$os-${x64 ? 'x64' : 'ia32'}."
           "${os == 'windows' ? 'zip' : 'tar.gz'}";
 

--- a/test/testing_test.dart
+++ b/test/testing_test.dart
@@ -48,7 +48,7 @@ void main() {
         await pubGet();
 
         await _testCase("""
-          var process = await pkg.start("foo", []);
+          var process = await pkg.start("foo", [], encoding: utf8);
           expect(process.stdout, emits("in foo 1.2.3"));
           await process.shouldExit(0);
         """).create();
@@ -63,7 +63,7 @@ void main() {
         await pubGet();
 
         await _testCase("""
-          var process = await pkg.start("foo", []);
+          var process = await pkg.start("foo", [], encoding: utf8);
           expect(process.stderr, emitsThrough(contains("Failed assertion")));
           await process.shouldExit(255);
         """).create();
@@ -77,7 +77,7 @@ void main() {
         await (await grind(["pkg-standalone-dev"])).shouldExit(0);
 
         await _testCase("""
-          var process = await pkg.start("foo", []);
+          var process = await pkg.start("foo", [], encoding: utf8);
           expect(process.stdout, emits("in foo 1.2.3"));
           await process.shouldExit(0);
         """).create();
@@ -91,7 +91,8 @@ void main() {
         await _touch("my_app/bin/foo.dart");
 
         await _testCase("""
-          expect(pkg.start('foo', []), throwsA(isA<TestFailure>()));
+          expect(pkg.start('foo', [], encoding: utf8),
+            throwsA(isA<TestFailure>()));
         """).create();
         await (await _test()).shouldExit(0);
       });
@@ -102,7 +103,7 @@ void main() {
         await (await grind(["pkg-npm-dev"])).shouldExit(0);
 
         await _testCase("""
-          var process = await pkg.start("foo", [], node: true);
+          var process = await pkg.start("foo", [], node: true, encoding: utf8);
           expect(process.stdout, emits("in foo 1.2.3"));
           await process.shouldExit(0);
         """).create();
@@ -116,7 +117,8 @@ void main() {
         await _touch("my_app/bin/foo.dart");
 
         await _testCase("""
-          expect(pkg.start('foo', [], node: true), throwsA(isA<TestFailure>()));
+          expect(pkg.start('foo', [], node: true, encoding: utf8),
+            throwsA(isA<TestFailure>()));
         """).create();
         await (await _test()).shouldExit(0);
       });
@@ -354,6 +356,7 @@ void main() {
 /// test case that runs [code].
 d.FileDescriptor _testCase(String code) {
   return d.file("my_app/test.dart", """
+    import 'dart:convert';
     import 'dart:io';
 
     import 'package:test/test.dart';

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -95,6 +95,7 @@ Future<void> extract(String path, String destination) async {
 ///
 /// If [description] is passed
 Matcher after<T>(Object Function(T) transformation, Object matcher) =>
+  // TODO: no dynamic
     predicate((value) {
       expect(value, isA<T>());
       expect(transformation(value as T), matcher);

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -95,8 +95,7 @@ Future<void> extract(String path, String destination) async {
 ///
 /// If [description] is passed
 Matcher after<T>(Object? Function(T) transformation, Object matcher) =>
-  // TODO: no dynamic
-    predicate((dynamic value) {
+    predicate((value) {
       expect(value, isA<T>());
       expect(transformation(value as T), matcher);
       return true;

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -36,8 +36,8 @@ String get appDir => d.path("my_app");
 /// The [environment] and [forwardStdio] arguments have the same meanings as for
 /// [TestProcess.start].
 Future<TestProcess> grind(List<String> arguments,
-    {ShelfTestServer server,
-    Map<String, String> environment,
+    {ShelfTestServer? server,
+    Map<String, String>? environment,
     bool forwardStdio = false}) async {
   if (!File(d.path(p.join(appDir, ".packages"))).existsSync()) {
     await pubGet(forwardStdio: forwardStdio);
@@ -65,7 +65,7 @@ Future<void> pubGet({bool forwardStdio = false}) async {
 ///
 /// The Git process is run in [workingDirectory], which should be relative to
 /// [d.sandbox]. If it's not passed, [appDir] is used instead.
-Future<void> git(List<String> arguments, {String workingDirectory}) async {
+Future<void> git(List<String> arguments, {String? workingDirectory}) async {
   await (await TestProcess.start("git", arguments,
           workingDirectory: d.path(workingDirectory ?? appDir)))
       .shouldExit(0);
@@ -94,9 +94,9 @@ Future<void> extract(String path, String destination) async {
 /// it's been passed through the [transformation] function.
 ///
 /// If [description] is passed
-Matcher after<T>(Object Function(T) transformation, Object matcher) =>
+Matcher after<T>(Object? Function(T) transformation, Object matcher) =>
   // TODO: no dynamic
-    predicate((value) {
+    predicate((dynamic value) {
       expect(value, isA<T>());
       expect(transformation(value as T), matcher);
       return true;


### PR DESCRIPTION
This also removes the dependency on the `mustache` package (which seems to be unmaintained), instead just doing simple variable replacement with `replaceAll`.