### PR TITLE
Allow nullsafe versions of some dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   charcode: "^1.1.0"
   collection: ">=1.8.0 <2.0.0"
   crypto: ">=2.0.0 <4.0.0"
-  grinder: '^0.8.6'
+  grinder: '>=0.8.6 <0.10.0'
   http: ">=0.11.0 <0.13.0"
   js: "^0.6.0"
   meta: "^1.1.7"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   mustache: "^1.0.0"
   node_interop: "^1.1.0"
   node_preamble: ">=1.1.0 <3.0.0"
-  package_config: '^1.9.0'
+  package_config: '>=1.9.0 <3.0.0'
   path: '^1.0.0'
   pub_semver: '^1.0.0'
   pubspec_parse: '^0.1.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,14 +11,14 @@ dependencies:
   async: '>=1.13.0 <3.0.0'
   charcode: "^1.1.0"
   collection: ">=1.8.0 <2.0.0"
-  crypto: "^2.0.0"
+  crypto: ">=2.0.0 <4.0.0"
   grinder: '^0.8.6'
   http: ">=0.11.0 <0.13.0"
   js: "^0.6.0"
   meta: "^1.1.7"
   mustache: "^1.0.0"
   node_interop: "^1.1.0"
-  node_preamble: "^1.1.0"
+  node_preamble: ">=1.1.0 <3.0.0"
   package_config: '^1.9.0'
   path: '^1.0.0'
   pub_semver: '^1.0.0'
@@ -27,7 +27,7 @@ dependencies:
   test: '^1.0.0'
   test_process: '^1.0.0'
   xml: '^4.2.0'
-  yaml: '^2.0.0'
+  yaml: '>=2.0.0 <4.0.0'
 
 dev_dependencies:
   pedantic: '^1.6.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   string_scanner: '^1.0.0'
   test: '^1.0.0'
   test_process: '^1.0.0'
-  xml: '^4.2.0'
+  xml: '>=4.2.0 <6.0'
   yaml: '>=2.0.0 <4.0.0'
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   string_scanner: '^1.0.0'
   test: '^1.0.0'
   test_process: '^1.0.0'
-  xml: '>=4.2.0 <6.0'
+  xml: '>=4.2.0 <6.0.0'
   yaml: '>=2.0.0 <4.0.0'
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   node_preamble: ">=1.1.0 <3.0.0"
   package_config: '>=1.9.0 <3.0.0'
   path: '^1.0.0'
-  pub_semver: '^1.0.0'
+  pub_semver: '>=1.0.0 <3.0.0'
   pubspec_parse: '^0.1.0'
   string_scanner: '^1.0.0'
   test: '^1.0.0'


### PR DESCRIPTION
This is an attempt at unlocking the installation of `test` 1.16.7+ when running the dart-sass testsuite on dart 2.12+, to have the fix for `spawnHybridCode`