### PR TITLE
Run executables from source using their filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.5.1
+
+* Properly run executables from source in `testing.dart` when their public names
+  are different than their filenames.
+
 # 1.5.0
 
 * Add `pkg.npmAdditionalFiles` to make it possible to add custom files to npm

--- a/lib/testing.dart
+++ b/lib/testing.dart
@@ -150,12 +150,15 @@ List<String> executableArgs(String executable, {bool node = false}) {
   var snapshot = p.absolute("build/$executable.snapshot");
   if (File(snapshot).existsSync()) return [snapshot];
 
+  var path = executables.value[executable];
+  if (path == null) fail('There is no executable named "$executable".');
+
   verifyEnvironmentConstants();
   return [
     for (var entry in environmentConstants.value.entries)
       '-D${entry.key}=${entry.value}',
     "--enable-asserts",
-    p.absolute("bin/$executable.dart")
+    p.absolute(path)
   ];
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_pkg
-version: 1.5.0
+version: 1.5.1
 description: Grinder tasks for releasing Dart CLI packages.
 homepage: https://github.com/google/dart_cli_pkg
 

--- a/test/testing_test.dart
+++ b/test/testing_test.dart
@@ -15,7 +15,6 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:test_process/test_process.dart';
 

--- a/test/testing_test.dart
+++ b/test/testing_test.dart
@@ -15,6 +15,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:test_process/test_process.dart';
 
@@ -49,6 +50,29 @@ void main() {
 
         await _testCase("""
           var process = await pkg.start("foo", [], encoding: utf8);
+          expect(process.stdout, emits("in foo 1.2.3"));
+          await process.shouldExit(0);
+        """).create();
+
+        await (await _test()).shouldExit(0);
+      });
+
+      test("runs an executable with a different filename", () async {
+        await d.package({
+          ...pubspec,
+          "executables": {"bar": "foo"}
+        }, """
+          void main(List<String> args) {
+            pkg.addNpmTasks();
+            pkg.addStandaloneTasks();
+            grind(args);
+          }
+        """).create();
+
+        await pubGet();
+
+        await _testCase("""
+          var process = await pkg.start("bar", [], encoding: utf8);
           expect(process.stdout, emits("in foo 1.2.3"));
           await process.shouldExit(0);
         """).create();


### PR DESCRIPTION
Previously, we had been trying to use their public names, which are
not necessarily the same.