### PR TITLE
Allow all config variable functions to return null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.7.0
+
+* Callbacks passed to `ConfigVariable.fn=` can now return nullable values even
+  for non-nullable types. Doing so will cause the variable to use its default
+  value. The behavior for nullable types remains unchanged.
+
 # 1.6.0
 
 * Add `pkg-standalone-linux-arm64` and `pkg-standalone-mac-arm64` tasks, which

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_pkg
-version: 1.6.0
+version: 1.7.0
 description: Grinder tasks for releasing Dart CLI packages.
 homepage: https://github.com/google/dart_cli_pkg
 

--- a/test/config_variable_test.dart
+++ b/test/config_variable_test.dart
@@ -128,6 +128,20 @@ void main() {
       expect(variable.value, equals(12));
       expect(variable.value, equals(12));
     });
+
+    group("if the callback returns null", () {
+      test("uses the default value if T is non-nullable", () {
+        var variable = InternalConfigVariable.value(1);
+        variable.fn = expectAsync0(() => null, count: 1);
+        expect(variable.value, equals(1));
+      });
+
+      test("uses the default value if T is nullable", () {
+        var variable = InternalConfigVariable.value<int?>(1);
+        variable.fn = expectAsync0(() => null, count: 1);
+        expect(variable.value, isNull);
+      });
+    });
   });
 
   group("frozen", () {


### PR DESCRIPTION
If the config variable type is non-nullable, this causes it to return
its default value.