### PR TITLE
Work around a weird npm bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.1
+
+* Work around an npm bug that was causing `npm publish` to fail.
+
 # 2.0.0
 
 * **Breaking change:** The `jsRequires` map has been changed to a list of

--- a/lib/src/github.dart
+++ b/lib/src/github.dart
@@ -52,12 +52,11 @@ String? _repoFromOrigin() {
 /// Parses a GitHub repo name from an SSH reference or a `git://` URL.
 ///
 /// Returns `null` if it couldn't be parsed.
-String? _parseGit(String url) {
-  var match = RegExp(r"^(git@github\.com:|git://github\.com/)"
-          r"(?<repo>[^/]+/[^/]+?)(\.git)?$")
-      .firstMatch(url);
-  return match == null ? null : match.namedGroup('repo');
-}
+String? _parseGit(String url) =>
+    RegExp(r"^(git@github\.com:|git://github\.com/)"
+            r"(?<repo>[^/]+/[^/]+?)(\.git)?$")
+        .firstMatch(url)
+        ?.namedGroup('repo');
 
 /// Parses a GitHub repo name from an HTTP or HTTPS URL.
 ///

--- a/lib/src/npm.dart
+++ b/lib/src/npm.dart
@@ -523,9 +523,11 @@ Future<void> _deploy() async {
   file.writeStringSync("\n//registry.npmjs.org/:_authToken=$npmToken");
   file.closeSync();
 
-  log("npm publish --tag $npmDistTag build/npm");
+  // The trailing slash in "build/npm/" is necessary to avoid NPM trying to
+  // treat the path name as a GitHub repository slug.
+  log("npm publish --tag $npmDistTag build/npm/");
   var process = await Process.start(
-      "npm", ["publish", "--tag", npmDistTag.value, "build/npm"]);
+      "npm", ["publish", "--tag", npmDistTag.value, "build/npm/"]);
   LineSplitter().bind(utf8.decoder.bind(process.stdout)).listen(log);
   LineSplitter().bind(utf8.decoder.bind(process.stderr)).listen(log);
   if (await process.exitCode != 0) fail("npm publish failed");

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,6 @@ dependencies:
   yaml: ^3.1.0
 
 dev_dependencies:
-  pedantic: ^1.11.0
   sass_analysis:
     git: {url: git://github.com/sass/dart-sass, path: analysis}
   shelf: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_pkg
-version: 2.0.0
+version: 2.0.1
 description: Grinder tasks for releasing Dart CLI packages.
 homepage: https://github.com/google/dart_cli_pkg
 


### PR DESCRIPTION
Apparently, "npm publish foo/bar" tries to treat "foo/bar" as a GitHub
slug now rather than a path.