### PR TITLE
Generate the correct "main" package.json field for JSRequires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.0.2
+
+* Fix a bug where an `npm` package with target-specific `JSRequire`s would
+  include an invalid `"main"` field in its `package.json`.
+
 # 2.0.1
 
 * Work around an npm bug that was causing `npm publish` to fail.

--- a/lib/src/npm.dart
+++ b/lib/src/npm.dart
@@ -438,7 +438,7 @@ Future<void> _buildPackage() async {
         "version": version.toString(),
         "bin": {for (var name in executables.value.keys) name: "$name.js"},
         if (jsModuleMainLibrary.value != null)
-          "main": "$_npmName.dart${_needsRequireWrapper ? '.default' : ''}.js",
+          "main": "$_npmName${_needsRequireWrapper ? '.default' : ''}.dart.js",
         if (_needsRequireWrapper)
           "exports": {
             if (nodeRequires.isNotEmpty) "node": "./$_npmName.node.dart.js",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_pkg
-version: 2.0.1
+version: 2.0.2
 description: Grinder tasks for releasing Dart CLI packages.
 homepage: https://github.com/google/dart_cli_pkg
 


### PR DESCRIPTION
We were generating "<pkg>.dart.default.js", but it should be
"<pkg>.default.dart.js".