### PR TITLE
Add Support to create and upload Debian Packages

### DIFF
--- a/doc/debian.md
+++ b/doc/debian.md
@@ -1,0 +1,37 @@
+This task updates an existing Debian PPA repository with the latest `.deb` files for this package in both `x64` and `ia32` architectures. It's enabled by calling `pkg.addDebianTasks()`.
+
+By default, the task assumes that the GPG key for signing the PPA repository is already imported. If `pkg.gpgPrivateKey` is set, then it imports the GPG key and also sets the GPG fingerprint while importing the key.
+
+This task assumes that the PPA repository is on GitHub (specifically to [`pkg.githubRepo`][]), and that the task is running in a clone of that GitHub repo.
+
+[`pkg.githubrepo`]: https://pub.dev/documentation/cli_pkg/latest/cli_pkg/githubRepo.html
+
+## Usage
+
+To publish the debian packages on the PPA repository hosted on GitHub Pages,
+
+1. Create a repository on GitHub to host as the PPA repository. Setup instructions can be found [here](https://assafmo.github.io/2019/05/02/ppa-repo-hosted-on-github.html).
+2. Place the control file for the Debian packages in the PPA repository. Set the `pkg.debianControlPath` with the path to this file. The above two steps are to be performed for the initial setup only.
+3. Set the configuration variables for the task. If the GPG key is already present on the system, do not set the `pkg.gpgPrivateKey`.
+4. Use the `pkg.addDebianTasks()` to add the Debian task to Grinder.
+
+## `pkg-debian-update`
+
+Uses configuration: [`pkg.version`][], [`pkg.humanName`][], [`pkg.botName`][],
+[`pkg.botEmail`][], [`pkg.githubRepo`][], [`pkg.githubUser`][],
+[`pkg.githubPassword`][], [`pkg.debianRepo`][], [`pkg.debianControlPath`][],
+[`pkg.gpgFingerprint`][], [`pkg.gpgPassphrase`][], [`pkg.gpgPrivateKey`][]
+
+[`pkg.version`]: https://pub.dev/documentation/cli_pkg/latest/cli_pkg/version.html
+[`pkg.humanname`]: https://pub.dev/documentation/cli_pkg/latest/cli_pkg/humanName.html
+[`pkg.botname`]: https://pub.dev/documentation/cli_pkg/latest/cli_pkg/botName.html
+[`pkg.botemail`]: https://pub.dev/documentation/cli_pkg/latest/cli_pkg/botEmail.html
+[`pkg.githubuser`]: https://pub.dev/documentation/cli_pkg/latest/cli_pkg/githubUser.html
+[`pkg.githubpassword`]: https://pub.dev/documentation/cli_pkg/latest/cli_pkg/githubPassword.html
+[`pkg.debianrepo`]: https://pub.dev/documentation/cli_pkg/latest/cli_pkg/debianRepo.html
+[`pkg.debiancontrolpath`]: https://pub.dev/documentation/cli_pkg/latest/cli_pkg/debianControlPath.html
+[`pkg.gpgfingerprint`]: https://pub.dev/documentation/cli_pkg/latest/cli_pkg/gpgFingerprint.html
+[`pkg.gpgprivatekey`]: https://pub.dev/documentation/cli_pkg/latest/cli_pkg/gpgPrivateKey.html
+[`pkg.gpgpassphrase`]: https://pub.dev/documentation/cli_pkg/latest/cli_pkg/gpgPassphrase.html
+
+Checks out [`pkg.debianRepo`][] and pushes a commit updating the repository with the latest packages.

--- a/lib/cli_pkg.dart
+++ b/lib/cli_pkg.dart
@@ -18,6 +18,7 @@ import 'src/homebrew.dart';
 import 'src/npm.dart';
 import 'src/pub.dart';
 import 'src/standalone.dart';
+import 'src/debian.dart';
 
 export 'src/chocolatey.dart';
 export 'src/config_variable.dart' hide InternalConfigVariable;
@@ -29,6 +30,7 @@ export 'src/js_require_target.dart';
 export 'src/npm.dart';
 export 'src/pub.dart';
 export 'src/standalone.dart';
+export 'src/debian.dart';
 
 /// Enables all tasks from the `cli_pkg` package.
 void addAllTasks() {
@@ -38,4 +40,5 @@ void addAllTasks() {
   addNpmTasks();
   addPubTasks();
   addStandaloneTasks();
+  addDebianTasks();
 }

--- a/lib/src/debian.dart
+++ b/lib/src/debian.dart
@@ -1,0 +1,133 @@
+import 'dart:io';
+
+import 'package:cli_pkg/src/standalone.dart';
+import 'package:grinder/grinder.dart';
+import 'package:path/path.dart' as p;
+
+import 'config_variable.dart';
+import 'github.dart';
+import 'info.dart';
+import 'utils.dart';
+
+/// The GitHub repository slug (for example, `username/repo`) of the PPA
+/// repository for this package.
+///
+/// This must be set explicitly.
+final debianRepo = InternalConfigVariable.fn<String>(
+    () => fail("pkg.debianRepo must be set to deploy to PPA repository."));
+
+/// The contents of the debian packages's control file.
+///
+/// By default, it is loaded from `control` at the root of the repository.
+/// It's modifiable.
+///
+/// `cli_pkg` will automatically update the `version` field when building the package.
+final controlData = InternalConfigVariable.fn<String>(() =>
+    File("control").existsSync()
+        ? File("control").readAsStringSync()
+        : fail("pkg.controlData must be set to update Debian package."));
+
+/// The fingerprint for GPG key to use when signing the release.
+///
+/// By default, this comes from the `GPG_FINGERPRINT` environment variable.
+final gpgFingerprint = InternalConfigVariable.fn<String>(() =>
+    Platform.environment["GPG_FINGERPRINT"] ??
+    fail("pkg.gpgPassphrase must be set to deploy to PPA repository."));
+
+/// The passphrase for the GPG key to use when signing the release.
+///
+/// By default, this comes from the `GPG_PASSPHRASE` environment variable.
+final gpgPassphrase = InternalConfigVariable.fn<String>(() =>
+    Platform.environment["GPG_PASSPHRASE"] ??
+    fail("pkg.gpgPassphrase must be set to deploy to PPA repository."));
+
+/// Whether [addDebianTasks] has been called yet.
+var _addedDebianTasks = false;
+
+/// Adds the task to create and upload the new package to the PPA.
+void addDebianTasks() {
+  if (!Platform.isLinux) {
+    fail("Platform must be linux for this task.");
+  }
+
+  if (_addedDebianTasks) return;
+  _addedDebianTasks = true;
+
+  freezeSharedVariables();
+  debianRepo.freeze();
+  controlData.freeze();
+  gpgFingerprint.freeze();
+  gpgPassphrase.freeze();
+
+  addTask(GrinderTask('pkg-debian-update',
+      taskFunction: () => _update(),
+      description: 'Update the Debian package.',
+      depends: ['pkg-standalone-linux-x64']));
+}
+
+/// Releases the source code in a Debian package and
+/// updates the PPA repository with the new package.
+Future<void> _update() async {
+  ensureBuild();
+
+  final String packageName = standaloneName.value + "_" + version.toString();
+  var repo =
+      await cloneOrPull(url("https://github.com/$debianRepo.git").toString());
+
+  await _createDebianPackage(repo, packageName);
+  // TODO: Functions to Release and Upload the package to Git Upstream
+}
+
+/// Creates a Debian package from the source code.
+Future<void> _createDebianPackage(String repo, String packageName) async {
+  String debianDir = await _createPackageDirectory(repo, packageName);
+
+  _generateControlFile(debianDir);
+  _copyExecutableFiles(debianDir);
+  // Pack the files into a .deb file
+  run("dpkg-deb", arguments: ["--build", packageName], workingDirectory: repo);
+  await _removeDirectory(debianDir);
+}
+
+/// Delete the Directory with path [directory].
+Future<void> _removeDirectory(String directory) async {
+  var result = await Process.run("rm", ["-r", directory]);
+  if (result.exitCode != 0) {
+    fail('Unable to remove the directory\n${result.stderr}');
+  }
+}
+
+/// Create the directory `repo/packageName` and relevant subfolders for the
+/// debian package.
+///
+/// Returns the path of created folder.
+Future<String> _createPackageDirectory(String repo, String packageName) async {
+  String debianDir = p.join(repo, packageName);
+  await Directory('$debianDir/DEBIAN').create(recursive: true);
+  await Directory('$debianDir/usr/local/bin').create(recursive: true);
+  return debianDir;
+}
+
+/// Copy all executable files listed in the map [executables] from the `build` folder
+void _copyExecutableFiles(String debianDir) {
+  final executablePath = p.join(debianDir, "usr", "local", "bin");
+  executables.value.forEach((name, path) {
+    run("cp", arguments: [
+      p.join("build", "$name.native"),
+      p.join(executablePath, name)
+    ]);
+  });
+}
+
+/// Generate the control file for the Debian package.
+void _generateControlFile(String debianDir) {
+  var controlFilePath = p.join(debianDir, "DEBIAN", "control");
+
+  String _updatedControlData = replaceFirstMappedMandatory(
+      controlData.value,
+      RegExp(r'Version: ([0-9].*)'),
+      (match) => 'Version: ${version.toString()}',
+      "Couldn't find a version field in the given CONTROL file.");
+
+  writeString(controlFilePath, _updatedControlData);
+}

--- a/lib/src/debian.dart
+++ b/lib/src/debian.dart
@@ -89,7 +89,7 @@ void addDebianTasks() {
 Future<void> _update() async {
   ensureBuild();
 
-  final String packageName = standaloneName.value + "_" + version.toString();
+  var packageName = standaloneName.value + "_" + version.toString();
   var repo =
       await cloneOrPull(url("https://github.com/$debianRepo.git").toString());
 
@@ -227,7 +227,6 @@ void _importGpgPrivateKey() {
       ..._gpgArgs,
       "--passphrase",
       gpgPassphrase.value,
-      "--allow-secret-key-import",
       "--import",
       "._privateKey"
     ],

--- a/lib/src/debian.dart
+++ b/lib/src/debian.dart
@@ -87,7 +87,7 @@ Future<void> _update() async {
 
   await _createDebianPackage(repo, packageName);
   await _releaseNewPackage(repo);
-  // TODO: Function to Upload the package to the Git repository.
+  await _gitUpdateAndPush(repo);
 }
 
 /// Creates a Debian package from the source code.
@@ -196,5 +196,32 @@ Future<void> _updateInReleaseFile(String repo) async {
         "Release",
       ],
       quiet: true,
+      workingDirectory: repo);
+}
+
+/// Commit all the changes in the PPA repository and push to the remote upstream.
+Future<void> _gitUpdateAndPush(String repo) async {
+  run("git",
+      arguments: ["add", "."],
+      workingDirectory: repo,
+      runOptions: botEnvironment);
+
+  run("git",
+      arguments: [
+        "commit",
+        "--all",
+        "--message",
+        "Update $humanName to $version"
+      ],
+      workingDirectory: repo,
+      runOptions: botEnvironment);
+
+  await runAsync("git",
+      arguments: [
+        "push",
+        url("https://$githubUser:$githubPassword@github.com/$debianRepo.git")
+            .toString(),
+        "HEAD:${await originHead(repo)}"
+      ],
       workingDirectory: repo);
 }

--- a/lib/src/homebrew.dart
+++ b/lib/src/homebrew.dart
@@ -129,7 +129,7 @@ Future<void> _update() async {
         "push",
         url("https://$githubUser:$githubPassword@github.com/$homebrewRepo.git")
             .toString(),
-        "HEAD:${await _originHead(repo)}"
+        "HEAD:${await originHead(repo)}"
       ],
       workingDirectory: repo);
 }
@@ -167,28 +167,6 @@ String _formulaFile(String repo) {
   } else {
     return entries.single;
   }
-}
-
-/// Returns the name of HEAD in the origin remote (that is, the default branch
-/// name of the upstream repository).
-Future<String> _originHead(String repo) async {
-  var result = await Process.run(
-      "git", ["symbolic-ref", "refs/remotes/origin/HEAD"],
-      workingDirectory: repo);
-  if (result.exitCode != 0) {
-    fail('"git symbolic-ref refs/remotes/origin/HEAD" failed:\n'
-        '${result.stderr}');
-  }
-
-  var stdout = (result.stdout as String).trim();
-  var prefix = "refs/remotes/origin/";
-  if (!stdout.startsWith(prefix)) {
-    fail('Unexpected output from "git symbolic-ref refs/remotes/origin/HEAD":\n'
-        'Expected a string starting with "$prefix", got:\n'
-        '$stdout');
-  }
-
-  return stdout.substring(prefix.length);
 }
 
 /// Converts [version] into the format Homebrew expects in an `@`-versioned

--- a/lib/src/homebrew.dart
+++ b/lib/src/homebrew.dart
@@ -82,20 +82,20 @@ Future<void> _update() async {
       await cloneOrPull(url("https://github.com/$homebrewRepo.git").toString());
 
   var formulaPath = _formulaFile(repo);
-  var formula = _replaceFirstMappedMandatory(
+  var formula = replaceFirstMappedMandatory(
       File(formulaPath).readAsStringSync(),
       RegExp(r'\n( *)url "[^"]+"'),
       (match) => '\n${match[1]}url '
           '"https://github.com/$githubRepo/archive/$homebrewTag.tar.gz"',
       "Couldn't find a url field in $formulaPath.");
-  formula = _replaceFirstMappedMandatory(
+  formula = replaceFirstMappedMandatory(
       formula,
       RegExp(r'\n( *)sha256 "[^"]+"'),
       (match) => '\n${match[1]}sha256 "$digest"',
       "Couldn't find a sha256 field in $formulaPath.");
 
   if (homebrewCreateVersionedFormula.value) {
-    formula = _replaceFirstMappedMandatory(
+    formula = replaceFirstMappedMandatory(
         formula,
         RegExp(r'^ *class ([^ <]+) *< *Formula *$', multiLine: true),
         (match) => 'class ${match[1]}AT${_classify(version)} < Formula',
@@ -132,19 +132,6 @@ Future<void> _update() async {
         "HEAD:${await originHead(repo)}"
       ],
       workingDirectory: repo);
-}
-
-/// Like [String.replaceFirstMapped], but fails with [error] if no match is found.
-String _replaceFirstMappedMandatory(
-    String string, Pattern from, String replace(Match match), String error) {
-  var found = false;
-  var result = string.replaceFirstMapped(from, (match) {
-    found = true;
-    return replace(match);
-  });
-
-  if (!found) fail(error);
-  return result;
 }
 
 /// Returns the path to the formula file to update in [repo].

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -401,3 +401,25 @@ String windowsArgEscape(String value) {
   buffer.writeCharCode($double_quote);
   return buffer.toString();
 }
+
+/// Returns the name of HEAD in the origin remote (that is, the default branch
+/// name of the upstream repository).
+Future<String> originHead(String repo) async {
+  var result = await Process.run(
+      "git", ["symbolic-ref", "refs/remotes/origin/HEAD"],
+      workingDirectory: repo);
+  if (result.exitCode != 0) {
+    fail('"git symbolic-ref refs/remotes/origin/HEAD" failed:\n'
+        '${result.stderr}');
+  }
+
+  var stdout = (result.stdout as String).trim();
+  var prefix = "refs/remotes/origin/";
+  if (!stdout.startsWith(prefix)) {
+    fail('Unexpected output from "git symbolic-ref refs/remotes/origin/HEAD":\n'
+        'Expected a string starting with "$prefix", got:\n'
+        '$stdout');
+  }
+
+  return stdout.substring(prefix.length);
+}

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -423,3 +423,16 @@ Future<String> originHead(String repo) async {
 
   return stdout.substring(prefix.length);
 }
+
+/// Like [String.replaceFirstMapped], but fails with [error] if no match is found.
+String replaceFirstMappedMandatory(
+    String string, Pattern from, String replace(Match match), String error) {
+  var found = false;
+  var result = string.replaceFirstMapped(from, (match) {
+    found = true;
+    return replace(match);
+  });
+
+  if (!found) fail(error);
+  return result;
+}


### PR DESCRIPTION
Fixes #95.

- Import of GPG keys is now available with an option to use external tools to import keys. (Also useful if keys are already present)
- The signing of the release files is now automated.

## **Work Left**
- Documentation for steps to use
- Tests for the module

If you do have any suggestions or corrections, please drop them below. Thanks.

## Description

The feature works by:
1. Creating a .deb package from the given executables. (mentioned in sass/dart-sass#1164)
2. Updating the Release files in the cloned PPA repo and then signing them.
3. Updating the remote PPA repo with the new packages.
4. It creates the Debian packages for both architectures `x64` and `ia32`.

## Usage 

To use this feature, 
1. Set the `debianRepo`, `signingEmail`, `controlData` config variables. 
2. Add the location of control file to `controlData` config.
3. Setup the GPG key import action. The key fingerprint and passphrase are taken from the secrets.
4. Use the `addDebianTasks` function to add the Debian task to Grinder. 