### PR TITLE
Narrow the SDK constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.1
+
+* Narrow the SDK constraint to reflect the use of a new API.
+
 # 2.1.0
 
 * Add `pkg-github-$os-$arch` tasks, which compile and upload binaries for the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: cli_pkg
-version: 2.1.0
+version: 2.1.1
 description: Grinder tasks for releasing Dart CLI packages.
 homepage: https://github.com/google/dart_cli_pkg
 
 environment:
-  sdk: '>=2.14.0 <3.0.0'
+  sdk: '>=2.16.0 <3.0.0'
 
 dependencies:
   archive: ^3.1.2


### PR DESCRIPTION
PR #98 added a use of the `Abi` class from `dart:ffi`, which was only
added in Dart 2.16.0.