### PR TITLE
Fix dart pub publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.1.2
+
+* Use `dart pub` commands rather than `pub` for compatibility with the latest
+  Dart releases.
+
 # 2.1.1
 
 * Narrow the SDK constraint to reflect the use of a new API.

--- a/lib/src/pub.dart
+++ b/lib/src/pub.dart
@@ -62,10 +62,10 @@ Future<void> _deploy() async {
     ..writeStringSync(pubCredentials.value)
     ..closeSync();
 
-  log("pub publish");
+  log("dart pub publish");
   var process = await Process.start(
-      p.join(sdkDir.path, "bin/pub$dotBat"), ["publish", "--force"]);
+      p.join(sdkDir.path, "bin/dart$dotExe"), ["pub", "publish", "--force"]);
   LineSplitter().bind(utf8.decoder.bind(process.stdout)).listen(log);
   LineSplitter().bind(utf8.decoder.bind(process.stderr)).listen(log);
-  if (await process.exitCode != 0) fail("pub publish failed");
+  if (await process.exitCode != 0) fail("dart pub publish failed");
 }

--- a/lib/testing.dart
+++ b/lib/testing.dart
@@ -29,8 +29,8 @@ final _executableUpToDateCache = p.PathSet();
 
 /// Whether this package has any path dependencies.
 ///
-/// When a package has path dependencies, `pub run` updates the modification
-/// time on the `pubspec.lock` file after every run, which means
+/// When a package has path dependencies, `dart pub run` updates the
+/// modification time on the `pubspec.lock` file after every run, which means
 /// [ensureUpToDate] can't reliably use it for freshness checking.
 final _hasPathDependency = _dependenciesHasPath(pubspec.dependencies) ||
     _dependenciesHasPath(pubspec.devDependencies) ||
@@ -179,7 +179,7 @@ void ensureExecutableUpToDate(String executable, {bool node = false}) {
 
   if (!_executableUpToDateCache.contains(path)) {
     ensureUpToDate(
-        path, "pub run grinder pkg-${node ? 'npm' : 'standalone'}-dev",
+        path, "dart pub run grinder pkg-${node ? 'npm' : 'standalone'}-dev",
         dependencies: [executables.value[executable]]);
 
     // Only add this after ensuring that the executable is up-to-date, so that

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_pkg
-version: 2.1.1
+version: 2.1.2
 description: Grinder tasks for releasing Dart CLI packages.
 homepage: https://github.com/google/dart_cli_pkg
 


### PR DESCRIPTION
Top level pub has been removed in the latest stable sdk, and there is one more usage (the most important one) that was missed on previous changes.