### PR TITLE
Replace deprecated `dart pub run` with `dart run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.6
+
+* Use `dart run` commands rather than `dart pub run` for compatibility with the
+  latest Dart releases.
+
 ## 2.1.5
 
 * **Potentially breaking bug fix:** The `pkg-homebrew-update` task must now

--- a/lib/testing.dart
+++ b/lib/testing.dart
@@ -29,7 +29,7 @@ final _executableUpToDateCache = p.PathSet();
 
 /// Whether this package has any path dependencies.
 ///
-/// When a package has path dependencies, `dart pub run` updates the
+/// When a package has path dependencies, `dart run` updates the
 /// modification time on the `pubspec.lock` file after every run, which means
 /// [ensureUpToDate] can't reliably use it for freshness checking.
 final _hasPathDependency = _dependenciesHasPath(pubspec.dependencies) ||

--- a/lib/testing.dart
+++ b/lib/testing.dart
@@ -179,7 +179,7 @@ void ensureExecutableUpToDate(String executable, {bool node = false}) {
 
   if (!_executableUpToDateCache.contains(path)) {
     ensureUpToDate(
-        path, "dart pub run grinder pkg-${node ? 'npm' : 'standalone'}-dev",
+        path, "dart run grinder pkg-${node ? 'npm' : 'standalone'}-dev",
         dependencies: [executables.value[executable]]);
 
     // Only add this after ensuring that the executable is up-to-date, so that

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_pkg
-version: 2.1.5
+version: 2.1.6
 description: Grinder tasks for releasing Dart CLI packages.
 homepage: https://github.com/google/dart_cli_pkg
 


### PR DESCRIPTION
This PR replaces deprecated `dart pub run` with `dart run`.

```
$ dart pub run
Deprecated. Use `dart run` instead.
```