### PR TITLE
Update test package versions to allow Dart 3.0.0

### DIFF
--- a/test/chocolatey_test.dart
+++ b/test/chocolatey_test.dart
@@ -199,7 +199,7 @@ void main() {
                 json.encode({
                   "name": "direct_dep",
                   "version": "1.0.0",
-                  "environment": {"sdk": ">=2.0.0 <3.0.0"},
+                  "environment": {"sdk": ">=2.0.0 <4.0.0"},
                 })),
             d.file("LICENSE.md", "Direct dependency license")
           ]).create();
@@ -230,7 +230,7 @@ void main() {
                 json.encode({
                   "name": "direct_dep",
                   "version": "1.0.0",
-                  "environment": {"sdk": ">=2.0.0 <3.0.0"},
+                  "environment": {"sdk": ">=2.0.0 <4.0.0"},
                   "dependencies": {
                     "indirect_dep": {"path": "../indirect_dep"}
                   }
@@ -243,7 +243,7 @@ void main() {
                 json.encode({
                   "name": "indirect_dep",
                   "version": "1.0.0",
-                  "environment": {"sdk": ">=2.0.0 <3.0.0"}
+                  "environment": {"sdk": ">=2.0.0 <4.0.0"}
                 })),
             d.file("COPYING", "Indirect dependency license")
           ]).create();

--- a/test/npm_test.dart
+++ b/test/npm_test.dart
@@ -780,7 +780,7 @@ void main() {
             json.encode({
               "name": "direct_dep",
               "version": "1.0.0",
-              "environment": {"sdk": ">=2.0.0 <3.0.0"},
+              "environment": {"sdk": ">=2.0.0 <4.0.0"},
               "dependencies": {
                 "indirect_dep": {"path": "../indirect_dep"}
               }
@@ -794,7 +794,7 @@ void main() {
             json.encode({
               "name": "indirect_dep",
               "version": "1.0.0",
-              "environment": {"sdk": ">=2.0.0 <3.0.0"}
+              "environment": {"sdk": ">=2.0.0 <4.0.0"}
             })),
         d.file("COPYING", "Indirect dependency license")
       ]).create();

--- a/test/standalone_test.dart
+++ b/test/standalone_test.dart
@@ -275,7 +275,7 @@ void main() {
             json.encode({
               "name": "direct_dep",
               "version": "1.0.0",
-              "environment": {"sdk": ">=2.0.0 <3.0.0"},
+              "environment": {"sdk": ">=2.0.0 <4.0.0"},
               "dependencies": {
                 "indirect_dep": {"path": "../indirect_dep"}
               }
@@ -289,7 +289,7 @@ void main() {
             json.encode({
               "name": "indirect_dep",
               "version": "1.0.0",
-              "environment": {"sdk": ">=2.0.0 <3.0.0"}
+              "environment": {"sdk": ">=2.0.0 <4.0.0"}
             })),
         d.file("COPYING", "Indirect dependency license")
       ]).create();


### PR DESCRIPTION
This is now the version of the dev branch, so dev tests are failing if
we exclude it.