### PR TITLE
Generate a native snapshot rather than a self-contained executable on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0
+
+* Generate a native snapshot rather than a self-contained executable on Linux.
+
 ## 2.1.9
 
 * Use `readlink -f` in standalone scripts that wrap snapshots on operating

--- a/lib/src/standalone.dart
+++ b/lib/src/standalone.dart
@@ -32,9 +32,13 @@ import 'utils.dart';
 /// generated for the current operating system in 64-bit mode, so [_useNative]
 /// should be checked as well.
 ///
-/// This is currently only enabled on Linux because Windows and OS X generate
+/// This is currently disabled on Windows and OS X because they generate
 /// annoying warnings when running unsigned executables. See #67 for details.
-final _useExe = Platform.operatingSystem == "linux";
+///
+/// This is currently disabled on Linux because the self-contained executable
+/// can be broken due to the way trailing snapshot in ELF is handled.
+/// See https://github.com/dart-lang/sdk/issues/50926 for details.
+final _useExe = false;
 
 /// The name of the standalone package.
 ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_pkg
-version: 2.1.9
+version: 2.2.0
 description: Grinder tasks for releasing Dart CLI packages.
 homepage: https://github.com/google/dart_cli_pkg
 


### PR DESCRIPTION
- https://github.com/sass/dart-sass-embedded/issues/78
- https://github.com/dart-lang/sdk/issues/50926