### PR TITLE
Use current SDK when building snapshot for current architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.2.1
+
+* Use current SDK's `dart` executable to build standalone snapshot for current
+  architecture.
+
 ## 2.2.0
 
 * Generate a native snapshot rather than a self-contained executable on Linux.

--- a/lib/src/standalone.dart
+++ b/lib/src/standalone.dart
@@ -156,10 +156,15 @@ void addStandaloneTasks() {
 /// (dart-lang/sdk#47177).
 bool _useNative(String os, String arch) {
   _verifyOsAndArch(os, arch);
-  if ("${os}_$arch" != Abi.current().toString()) return false;
+  if (!_isCurrentOsAndArch(os, arch)) return false;
   if (arch == "ia32") return false;
 
   return true;
+}
+
+/// Returns whether currently running SDK matches [os] and [arch] combination.
+bool _isCurrentOsAndArch(String os, String arch) {
+  return "${os}_$arch" == Abi.current().toString();
 }
 
 /// Builds scripts for testing each executable on the current OS and
@@ -249,6 +254,9 @@ Future<List<int>> _dartExecutable(String os, String arch) async {
   if (_useNative(os, arch)) {
     return File(
             p.join(sdkDir.path, "bin/dartaotruntime${_binaryExtension(os)}"))
+        .readAsBytesSync();
+  } else if (_isCurrentOsAndArch(os, arch)) {
+    return File(p.join(sdkDir.path, "bin/dart${_binaryExtension(os)}"))
         .readAsBytesSync();
   } else if (isTesting) {
     // Don't actually download full SDKs in test mode, just return a dummy

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_pkg
-version: 2.2.0
+version: 2.2.1
 description: Grinder tasks for releasing Dart CLI packages.
 homepage: https://github.com/google/dart_cli_pkg
 


### PR DESCRIPTION
This PR avoids need to download another SDK when building snapshot standalone for current platform. E.g. on x86. 