### PR TITLE
Support experimental dart sdks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.4.0
+
+* Add standalone tasks for experimental dart sdks. These tasks are only
+  available directly on experimental dart sdks.
+
 ## 2.3.0
 
 * Added `pkg.jsEsmExports`. If this is set, `cli_pkg` will generate ESM

--- a/doc/standalone.md
+++ b/doc/standalone.md
@@ -98,6 +98,10 @@ host OS matches the target OS *and* the architecture is 64-bit, executables will
 be built as native (["AOT"][snapshot]) executables, which are substantially
 faster and smaller than the kernel snapshots that are generated otherwise.
 
+The target for the current OS and architecture is always available. However, for
+any OS or architecture under experimental Dart SDK support, such task is only
+available when building with the experimental Dart SDK directly.
+
 This produces a ZIP file in Windows, and a gzipped TAR file on Linux and Mac OS.
 
 Note that `pkg-standalone-macos-ia32` doesn't exist. The Dart SDK no longer has

--- a/lib/src/standalone.dart
+++ b/lib/src/standalone.dart
@@ -174,10 +174,13 @@ bool _useNative(String os, String arch) {
   return true;
 }
 
+/// List of strings containing the os and arch for the current Dart SDK.
 List<String> _currentOsAndArch = Abi.current().toString().split('_');
 
+/// The os of the current Dart SDK.
 String _currentOs = _currentOsAndArch[0];
 
+/// The arch of the current Dart SDK.
 String _currentArch = _currentOsAndArch[1];
 
 /// Returns whether currently running SDK matches [os] and [arch] combination.

--- a/lib/src/standalone.dart
+++ b/lib/src/standalone.dart
@@ -145,6 +145,18 @@ void addStandaloneTasks() {
   addTask(GrinderTask('pkg-standalone-all',
       description: 'Build all standalone packages.',
       depends: tasks.map((task) => task.name)));
+
+  // Add a task for current sdk if it is experimental.
+  var taskNameForCurrentAbi = "pkg-standalone-$_currentOs-$_currentArch";
+  if (!tasks.any((task) => task.name == taskNameForCurrentAbi)) {
+    addTask(GrinderTask(taskNameForCurrentAbi,
+        taskFunction: () => _buildPackage(_currentOs, _currentArch),
+        description:
+            'Build a standalone $_currentArch package for ${humanOSName(_currentOs)}.',
+        depends: _useNative(_currentOs, _currentArch)
+            ? ['pkg-compile-native']
+            : ['pkg-compile-snapshot']));
+  }
 }
 
 /// Returns whether to use the natively-compiled executable for the given [os]
@@ -162,9 +174,15 @@ bool _useNative(String os, String arch) {
   return true;
 }
 
+List<String> _currentOsAndArch = Abi.current().toString().split('_');
+
+String _currentOs = _currentOsAndArch[0];
+
+String _currentArch = _currentOsAndArch[1];
+
 /// Returns whether currently running SDK matches [os] and [arch] combination.
 bool _isCurrentOsAndArch(String os, String arch) {
-  return "${os}_$arch" == Abi.current().toString();
+  return os == _currentOs && arch == _currentArch;
 }
 
 /// Builds scripts for testing each executable on the current OS and
@@ -285,10 +303,8 @@ Future<List<int>> _dartExecutable(String os, String arch) async {
 ///
 /// This is just intended to guard against programmer error within `cli_pkg`.
 void _verifyOsAndArch(String os, String arch) {
-  if (!osToArchs.containsKey(os)) {
-    fail("Unknown operating system $os!");
-  } else if (!osToArchs[os]!.contains(arch)) {
-    fail("Unknown or unsupperted architecture $arch for ${humanOSName(os)}!");
+  if (!Abi.values.any((abi) => abi.toString() == '${os}_$arch')) {
+    fail("Unknown or unsupperted platform $os-$arch!");
   }
 }
 

--- a/lib/src/standalone.dart
+++ b/lib/src/standalone.dart
@@ -304,7 +304,7 @@ Future<List<int>> _dartExecutable(String os, String arch) async {
 /// This is just intended to guard against programmer error within `cli_pkg`.
 void _verifyOsAndArch(String os, String arch) {
   if (!Abi.values.any((abi) => abi.toString() == '${os}_$arch')) {
-    fail("Unknown or unsupperted platform $os-$arch!");
+    fail("Unknown or unsupported platform $os-$arch!");
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_pkg
-version: 2.3.0
+version: 2.4.0
 description: Grinder tasks for releasing Dart CLI packages.
 homepage: https://github.com/google/dart_cli_pkg
 


### PR DESCRIPTION
This PR allows a user to build on standalone package with experimental version of dart sdks. For example, user can use dev channel sdks on Windows Arm64 or Linux RISC-V to build natively for that platform.

This does not impact the `pkg-standalone-all` task which still only build all stable platforms.