### PR TITLE
Fix Chocolatey tests

### DIFF
--- a/test/chocolatey_test.dart
+++ b/test/chocolatey_test.dart
@@ -325,10 +325,10 @@ void main() {
       await (await grind(["pkg-chocolatey-pack"])).shouldExit(0);
 
       await (await TestProcess.start("choco", [
-        "install",
+        "install", "my_app_choco",
         // We already have Dart installed, and sometimes this fails to find it.
         "--ignore-dependencies",
-        d.path("my_app/build/my_app_choco.$version.nupkg")
+        "--source=" + d.path("my_app/build/my_app_choco.$version.nupkg")
       ]))
           .shouldExit(0);
 
@@ -374,10 +374,10 @@ void main() {
       await (await grind(["pkg-chocolatey-pack"])).shouldExit(0);
 
       await (await TestProcess.start("choco", [
-        "install",
+        "install", "my_app_choco",
         // We already have Dart installed, and sometimes this fails to find it.
         "--ignore-dependencies",
-        d.path("my_app/build/my_app_choco.$version.nupkg")
+        "--source=" + d.path("my_app/build/my_app_choco.$version.nupkg")
       ]))
           .shouldExit(0);
 

--- a/test/chocolatey_test.dart
+++ b/test/chocolatey_test.dart
@@ -326,6 +326,7 @@ void main() {
 
       await (await TestProcess.start("choco", [
         "install", "my_app_choco",
+        if (dartVersion.isPreRelease) "--pre",
         // We already have Dart installed, and sometimes this fails to find it.
         "--ignore-dependencies",
         "--source=" + d.path("my_app/build")
@@ -375,6 +376,7 @@ void main() {
 
       await (await TestProcess.start("choco", [
         "install", "my_app_choco",
+        if (dartVersion.isPreRelease) "--pre",
         // We already have Dart installed, and sometimes this fails to find it.
         "--ignore-dependencies",
         "--source=" + d.path("my_app/build")

--- a/test/chocolatey_test.dart
+++ b/test/chocolatey_test.dart
@@ -328,7 +328,7 @@ void main() {
         "install", "my_app_choco",
         // We already have Dart installed, and sometimes this fails to find it.
         "--ignore-dependencies",
-        "--source=" + d.path("my_app/build/my_app_choco.$version.nupkg")
+        "--source=" + d.path("my_app/build")
       ]))
           .shouldExit(0);
 
@@ -377,7 +377,7 @@ void main() {
         "install", "my_app_choco",
         // We already have Dart installed, and sometimes this fails to find it.
         "--ignore-dependencies",
-        "--source=" + d.path("my_app/build/my_app_choco.$version.nupkg")
+        "--source=" + d.path("my_app/build")
       ]))
           .shouldExit(0);
 


### PR DESCRIPTION
`choco install %PATH%` seems to fail flakily, so this uses `choco
install %PKGNAME% --source=%PATH%` instead.