### PR TITLE
Update dependencies; Dart SDK version to 3.0.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,18 @@
+## 2.5.0
+
+* Set the minimum Dart SDK version to `3.0.0`.
+  * sdk: '>=3.0.0 <4.0.0'
+
+* Update dependencies:
+  * http: ^1.1.0
+  * xml: ^6.3.0
+
 ## 2.4.7
-g
+
 * Fix a bug where npm packages could crash on Node.js if loaded both through
   `require()` and `import`.
+
+* http: ^1.1.0
 
 ## 2.4.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@
 * Fix a bug where npm packages could crash on Node.js if loaded both through
   `require()` and `import`.
 
-* http: ^1.1.0
-
 ## 2.4.6
 
 * Properly mark NPM packages as `"type": "module"` when `pkg.jsEsmExports` is

--- a/lib/src/chocolatey.dart
+++ b/lib/src/chocolatey.dart
@@ -18,7 +18,7 @@ import 'dart:io';
 import 'package:grinder/grinder.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
-import 'package:xml/xml.dart' hide parse;
+import 'package:xml/xml.dart';
 
 import 'config_variable.dart';
 import 'info.dart';
@@ -168,7 +168,7 @@ final XmlDocument _nuspec = () {
 XmlElement get _nuspecMetadata => _findElement(_nuspec.rootElement, "metadata");
 
 /// The name of the Chocolatey package.
-String get _chocolateyName => _findElement(_nuspecMetadata, "id").text;
+String get _chocolateyName => _findElement(_nuspecMetadata, "id").innerText;
 
 /// Whether [addChocolateyTasks] has been called yet.
 var _addedChocolateyTasks = false;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: cli_pkg
-version: 2.4.7
+version: 2.5.0
 description: Grinder tasks for releasing Dart CLI packages.
 homepage: https://github.com/google/dart_cli_pkg
 
 environment:
-  sdk: '>=2.16.0 <3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   archive: ^3.1.2
@@ -15,7 +15,7 @@ dependencies:
   crypto: ^3.0.0
   glob: ^2.0.0
   grinder: ^0.9.0
-  http: ^0.13.0
+  http: ^1.1.0
   js: ^0.6.3
   meta: ^1.3.0
   node_interop: ^2.0.0
@@ -29,7 +29,7 @@ dependencies:
   string_scanner: ^1.1.0
   test: ^1.16.7
   test_process: ^2.0.0
-  xml: ^5.0.2
+  xml: ^6.3.0
   yaml: ^3.1.0
 
 dev_dependencies:

--- a/test/chocolatey_test.dart
+++ b/test/chocolatey_test.dart
@@ -17,7 +17,7 @@ import 'dart:io';
 
 import 'package:test/test.dart';
 import 'package:test_process/test_process.dart';
-import 'package:xml/xml.dart' hide parse;
+import 'package:xml/xml.dart';
 
 import 'package:cli_pkg/src/chocolatey.dart';
 import 'package:cli_pkg/src/utils.dart';


### PR DESCRIPTION
Many packages that depends on `cli_pkg` can't be updated without update these dependencies and Dart SDK to 3.0.0+.