### PR TITLE
Add a `wrapJSExceptions()` function in a new JS-specific library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
+## 2.5.0
+
+* Add a `wrapJSException()` function in the new `package:cli_pkg/js.dart`
+  library to work around [dart-lang/sdk#53105]. This should be called around all
+  calls to JS callbacks to avoid unexpected crashes when exceptions are caught
+  by Dart code.
+
+  [dart-lang/sdk#53105]: https://github.com/dart-lang/sdk/issues/53105
+
+* Add a `pkg.jsForceStrictMode` configuration option. This defaults to `false`,
+  but if it's set to `true`, all generated JS code will be run in strict mode.
+
 ## 2.4.7
-g
+
 * Fix a bug where npm packages could crash on Node.js if loaded both through
   `require()` and `import`.
 

--- a/doc/npm.md
+++ b/doc/npm.md
@@ -45,13 +45,14 @@ library in addition to having its executables invoked. See
 
 Uses configuration: [`pkg.executables`][], [`pkg.version`][], [`pkg.jsFlags`][],
 [`pkg.jsDevFlags`][], [`pkg.jsRequires`][], [`pkg.jsModuleMainLibrary`][],
-[`pkg.npmPackageJson`][]
+[`pkg.jsForceStrictMode`][], [`pkg.npmPackageJson`][]
 
 [`pkg.executables`]: https://pub.dev/documentation/cli_pkg/latest/cli_pkg/executables.html
 [`pkg.version`]: https://pub.dev/documentation/cli_pkg/latest/cli_pkg/version.html
 [`pkg.jsFlags`]: https://pub.dev/documentation/cli_pkg/latest/cli_pkg/jsFlags.html
 [`pkg.jsDevFlags`]: https://pub.dev/documentation/cli_pkg/latest/cli_pkg/jsDevFlags.html
 [`pkg.jsRequires`]: https://pub.dev/documentation/cli_pkg/latest/cli_pkg/jsRequires.html
+[`pkg.jsForceStrictMode`]: https://pub.dev/documentation/cli_pkg/latest/cli_pkg/jsForceStrictMode.html
 
 Output: `build/$name.dart.js`
 
@@ -62,7 +63,7 @@ development mode. By default, development mode has all optimizations disabled.
 
 Uses configuration: [`pkg.executables`][], [`pkg.version`][], [`pkg.jsFlags`][],
 [`pkg.jsReleaseFlags`][], [`pkg.jsRequires`][], [`pkg.jsModuleMainLibrary`][],
-[`pkg.npmPackageJson`][]
+[`pkg.jsForceStrictMode`][], [`pkg.npmPackageJson`][]
 
 [`pkg.jsReleaseFlags`]: https://pub.dev/documentation/cli_pkg/latest/cli_pkg/jsReleaseFlags.html
 

--- a/lib/js.dart
+++ b/lib/js.dart
@@ -53,7 +53,9 @@ T wrapJSExceptions<T>(T Function() callback) {
     throw error;
   } catch (error) {
     if (typeofEquals<Object>(error, 'symbol') ||
-        typeofEquals<Object>(error, 'bigint')) {
+        typeofEquals<Object>(error, 'bigint') ||
+        // ignore: unnecessary_cast
+        (error as Object?) == null) {
       // Work around dart-lang/sdk#53106
       throw callMethod<String>(error, "toString", []);
     }

--- a/lib/js.dart
+++ b/lib/js.dart
@@ -1,0 +1,58 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:js/js_util.dart';
+
+/// Whether this Dart code is running in a strict mode context.
+///
+/// In strict mode, assigning properties to primitive types is an error. This
+/// uses that fact to sniff whether strict mode is in effect.
+final _isStrictMode = () {
+  try {
+    setProperty('', 'name', null);
+    return false;
+  } catch (_) {
+    return true;
+  }
+}();
+
+/// Runs [callback], wrapping any primitive JS objects it throws so they don't
+/// crash when caught by Dart code.
+///
+/// This works around [a bug] in Dart where primitive types such as strings
+/// thrown by JS will cause Dart code that catches them to crash in [strict mode]
+/// specifically. For safety, all calls to callbacks passed in from an external
+/// JS context should be wrapped in this function.
+///
+/// [a bug]: https://github.com/dart-lang/sdk/issues/53105
+/// [strict mode]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode
+T wrapJSExceptions<T>(T Function() callback) {
+  if (!_isStrictMode) return callback();
+
+  try {
+    return callback();
+  } on String catch (error) {
+    throw error;
+  } on bool catch (error) {
+    throw error;
+  } on num catch (error) {
+    throw error;
+  } catch (error) {
+    if (typeofEquals(error, 'symbol') || typeofEquals(error, 'bigint')) {
+      // Work around dart-lang/sdk#53106
+      throw callMethod(error, "toString", []);
+    }
+    rethrow;
+  }
+}

--- a/lib/js.dart
+++ b/lib/js.dart
@@ -43,15 +43,19 @@ T wrapJSExceptions<T>(T Function() callback) {
   try {
     return callback();
   } on String catch (error) {
+    // ignore: use_rethrow_when_possible
     throw error;
   } on bool catch (error) {
+    // ignore: use_rethrow_when_possible
     throw error;
   } on num catch (error) {
+    // ignore: use_rethrow_when_possible
     throw error;
   } catch (error) {
-    if (typeofEquals(error, 'symbol') || typeofEquals(error, 'bigint')) {
+    if (typeofEquals<Object>(error, 'symbol') ||
+        typeofEquals<Object>(error, 'bigint')) {
       // Work around dart-lang/sdk#53106
-      throw callMethod(error, "toString", []);
+      throw callMethod<String>(error, "toString", []);
     }
     rethrow;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_pkg
-version: 2.4.7
+version: 2.5.0
 description: Grinder tasks for releasing Dart CLI packages.
 homepage: https://github.com/google/dart_cli_pkg
 

--- a/test/descriptor.dart
+++ b/test/descriptor.dart
@@ -71,8 +71,8 @@ DirectoryDescriptor package(Map<String, dynamic> pubspec, String grindDotDart,
     file("pubspec.lock", File("pubspec.lock").readAsStringSync()),
 
     dir("bin", [
-      for (var basename in executables)
-        if (!_containsExecutable(basename))
+      for (var basename in executables.cast<String>())
+        if (!_containsExecutable(files, basename))
           file(
               "$basename.dart",
               // Include the version variable to ensure that executables we
@@ -96,12 +96,12 @@ DirectoryDescriptor package(Map<String, dynamic> pubspec, String grindDotDart,
 
 /// Returns whether [files] defines an executable named [basename].
 bool _containsExecutable(List<Descriptor>? descriptors, String basename) {
-  if (descriptors == null) return;
+  if (descriptors == null) return false;
   return descriptors.any((descriptor) =>
       (descriptor is DirectoryDescriptor &&
           descriptor.name == "bin" &&
           descriptor.contents.any((child) =>
-              child is FileDescriptor && file.name == "$basename.dart")) ||
+              child is FileDescriptor && child.name == "$basename.dart")) ||
       (descriptor is FileDescriptor &&
           descriptor.name == "bin/$basename.dart"));
 }

--- a/test/descriptor.dart
+++ b/test/descriptor.dart
@@ -72,12 +72,13 @@ DirectoryDescriptor package(Map<String, dynamic> pubspec, String grindDotDart,
 
     dir("bin", [
       for (var basename in executables)
-        file(
-            "$basename.dart",
-            // Include the version variable to ensure that executables we invoke
-            // have access to it.
-            'void main() => print("in $basename '
-                '\${const String.fromEnvironment("version")}");')
+        if (!_containsExecutable(basename))
+          file(
+              "$basename.dart",
+              // Include the version variable to ensure that executables we
+              // invoke have access to it.
+              'void main() => print("in $basename '
+                  '\${const String.fromEnvironment("version")}");')
     ]),
 
     dir("tool", [
@@ -91,6 +92,18 @@ DirectoryDescriptor package(Map<String, dynamic> pubspec, String grindDotDart,
 
     ...?files
   ]);
+}
+
+/// Returns whether [files] defines an executable named [basename].
+bool _containsExecutable(List<Descriptor>? descriptors, String basename) {
+  if (descriptors == null) return;
+  return descriptors.any((descriptor) =>
+      (descriptor is DirectoryDescriptor &&
+          descriptor.name == "bin" &&
+          descriptor.contents.any((child) =>
+              child is FileDescriptor && file.name == "$basename.dart")) ||
+      (descriptor is FileDescriptor &&
+          descriptor.name == "bin/$basename.dart"));
 }
 
 /// Returns the dependency description for `package` from `cli_pkg`'s own

--- a/test/npm_test.dart
+++ b/test/npm_test.dart
@@ -1128,6 +1128,12 @@ void main() {
 
       test("handles a thrown BigInt",
           () => assertCatchesGracefully('BigInt(123)'));
+
+      test("handles a thrown null",
+          () => assertCatchesGracefully('BigInt(null)'));
+
+      test("handles a thrown undefined",
+          () => assertCatchesGracefully('BigInt(undefined)'));
     });
   });
 }

--- a/test/npm_test.dart
+++ b/test/npm_test.dart
@@ -441,27 +441,27 @@ void main() {
         "name": "my_app",
         "version": "1.2.3",
       }, """
-        void main(List<String> args) {
-          pkg.jsModuleMainLibrary.value = "lib/src/exports.dart";
-          pkg.jsEsmExports.value = {};
-          pkg.executables.value = {"exec": "bin/exec.dart"};
+          void main(List<String> args) {
+            pkg.jsModuleMainLibrary.value = "lib/src/exports.dart";
+            pkg.jsEsmExports.value = {};
+            pkg.executables.value = {"exec": "bin/exec.dart"};
 
-          pkg.addNpmTasks();
-          grind(args);
-        }
-      """, [
+            pkg.addNpmTasks();
+            grind(args);
+          }
+        """, [
         _packageJson,
         d.dir("lib/src", [
           _exportsHello('"Hi, there!"'),
         ]),
         d.dir("bin", [
           d.file("exec.dart", r"""
-          import '../lib/src/exports.dart' as lib;
+            import '../lib/src/exports.dart' as lib;
 
-          void main(List<String> args) {
-            print("Hello from exec");
-          }
-        """)
+            void main(List<String> args) {
+              print("Hello from exec");
+            }
+          """)
         ]),
       ]).create();
 
@@ -470,6 +470,54 @@ void main() {
       var process = await TestProcess.start(
           "node$dotExe", [d.path("my_app/build/npm/exec.js")]);
       expect(process.stdout, emitsInOrder(["Hello from exec", emitsDone]));
+      await process.shouldExit(0);
+    });
+
+    var strictOrSloppy = r"""
+      import 'dart:js_util';
+
+      void main(List<String> args) {
+        try {
+          // This shouldn't throw an error in sloppy mode.
+          setProperty('', 'name', null);
+          print("sloppy mode");
+        } catch (_) {
+          print("strict mode");
+        }
+      }
+    """;
+
+    test("that run in sloppy mode by default", () async {
+      await d.package(pubspec, _enableNpm, [
+        _packageJson,
+        d.dir("bin", [d.file("foo.dart", strictOrSloppy)]),
+      ]).create();
+
+      await (await grind(["pkg-npm-dev"])).shouldExit();
+
+      var process = await TestProcess.start(
+          "node$dotExe", [d.path("my_app/build/npm/foo.js")]);
+      expect(process.stdout, emitsInOrder(["sloppy mode", emitsDone]));
+      await process.shouldExit(0);
+    });
+
+    test("that run in strict mode with jsForceStrictMode = true", () async {
+      await d.package(pubspec, r"""
+          void main(List<String> args) {
+            pkg.addNpmTasks();
+            pkg.jsForceStrictMode.value = true;
+            grind(args);
+          }
+        """, [
+        _packageJson,
+        d.dir("bin", [d.file("foo.dart", strictOrSloppy)]),
+      ]).create();
+
+      await (await grind(["pkg-npm-dev"])).shouldExit();
+
+      var process = await TestProcess.start(
+          "node$dotExe", [d.path("my_app/build/npm/foo.js")]);
+      expect(process.stdout, emitsInOrder(["strict mode", emitsDone]));
       await process.shouldExit(0);
     });
   });
@@ -1020,6 +1068,66 @@ void main() {
               contains("pkg.npmAdditionalFiles keys must be relative paths,")));
       expect(process.stderr, emits(contains("/foo/bar/baz.txt")));
       await process.shouldExit(1);
+    });
+  });
+
+  group("package:cli_pkg/js.dart", () {
+    group("wrapJSException in strict mode", () {
+      // Asserts that the JS [expression] doesn't crash when caught by Dart code
+      // after going through `wrapJSExceptions()`.
+      Future<void> assertCatchesGracefully(String expression) async {
+        await d.package(pubspec, r"""
+            void main(List<String> args) {
+              pkg.addNpmTasks();
+              pkg.jsForceStrictMode.value = true;
+              grind(args);
+            }
+          """, [
+          _packageJson,
+          d.dir("bin", [
+            d.file("foo.dart", """
+              import 'package:cli_pkg/js.dart';
+              import 'package:js/js.dart';
+
+              @JS("Function")
+              class _JSFunction {
+                external _JSFunction(String arguments, String body);
+                external Object? call();
+              }
+
+              void main() {
+                try {
+                  wrapJSExceptions(() {
+                    _JSFunction("error",
+                        "throw \${${json.encode(expression)}};").call();
+                  });
+                } catch (_, stackTrace) {
+                  print(stackTrace);
+                }
+              }
+            """)
+          ]),
+        ]).create();
+
+        await (await grind(["pkg-npm-dev"])).shouldExit();
+
+        var process = await TestProcess.start(
+            "node$dotExe", [d.path("my_app/build/npm/foo.js")]);
+        await process.shouldExit(0);
+      }
+
+      test(
+          "handles a thrown string", () => assertCatchesGracefully('"string"'));
+
+      test("handles a thrown boolean", () => assertCatchesGracefully('true'));
+
+      test("handles a thrown number", () => assertCatchesGracefully('123'));
+
+      test("handles a thrown Symbol",
+          () => assertCatchesGracefully('Symbol("foo")'));
+
+      test("handles a thrown BigInt",
+          () => assertCatchesGracefully('BigInt(123)'));
     });
   });
 }


### PR DESCRIPTION
This encapsulates a workaround for dart-lang/sdk#53105.