### PR TITLE
Improve JS environment detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.8.0
+
+* Make `isBrowser` and `isNodeJs` more reliable.
+
 ## 2.7.0
 
 * The `package:cli_pkg/js.dart` library can now be used by the Dart VM.

--- a/browser_library_test/test/node_js_helpers_in_browser_test.dart
+++ b/browser_library_test/test/node_js_helpers_in_browser_test.dart
@@ -20,6 +20,12 @@ import 'dart:js_util';
 import 'package:cli_pkg/js.dart';
 import 'package:test/test.dart';
 
+@JS('Object.defineProperty')
+external Object _defineProperty(Object obj, Object prop, Object descriptor);
+
+@JS('Symbol.toStringTag')
+external Object _toStringTag;
+
 void main() {
   group('isNodeJs', () {
     withNonNodeJsProcess(() {
@@ -37,7 +43,7 @@ void main() {
     });
 
     withFakedNodeJsProcess(() {
-      test('returns false', () => expect(isBrowser, isFalse));
+      test('returns true', () => expect(isBrowser, isTrue));
     });
   });
 
@@ -82,7 +88,11 @@ void withFakedNodeJsProcess(void Function() callback) {
   };
 
   group('fake Node.JS environment', () {
-    setUp(() => setProperty(globalThis, 'process', fakeNodeJsProcess.jsify()));
+    setUp(() => setProperty(
+        globalThis,
+        'process',
+        _defineProperty(fakeNodeJsProcess.jsify() as Object, _toStringTag,
+            ({'value': 'process'}).jsify() as Object)));
     callback();
     tearDown(() => delete<Object>(globalThis, 'process'));
   });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_pkg
-version: 2.7.0
+version: 2.8.0
 description: Grinder tasks for releasing Dart CLI packages.
 homepage: https://github.com/google/dart_cli_pkg
 


### PR DESCRIPTION
- Properly detect web workers as browser environment.
- `isBrowser` and `isNodeJs` are no longer mutually exclusive. If there is a super well made mock, then in that case both will return true as no one can tell.