### PR TITLE
Assign require to self

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.7.1
+
+* Make `require` available as a top-level name for JS interop. Dependencies
+  should still be defined declaratively through `jsRequires`, but this allows
+  Dart code to access attributes like `require.main`.
+
 ## 2.7.0
 
 * The `package:cli_pkg/js.dart` library can now be used by the Dart VM.

--- a/lib/src/npm.dart
+++ b/lib/src/npm.dart
@@ -549,8 +549,6 @@ globalThis._cliPkgExports.push(_cliPkgExports);
 
   buffer.writeln(preamble
       .getPreamble()
-      // Reassigning require() makes Webpack complain.
-      .replaceFirst("self.require = require;\n", "")
       // Allow library wrappers to pass in an explicit export variable.
       .replaceFirst("""
 if (typeof exports !== "undefined") {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_pkg
-version: 2.7.0
+version: 2.7.1
 description: Grinder tasks for releasing Dart CLI packages.
 homepage: https://github.com/google/dart_cli_pkg
 


### PR DESCRIPTION
In https://github.com/sass/dart-sass/issues/726, the line from `node_preamble` which sets `self.require = require` was removed to allow Webpack bundling. We have a need to access `self.require.main.filename`, so I would like to re-assign `require` to `self`.

In the interim, it looks like `node_preamble` moved to a `_cliPkgExports` strategy which prevents the underlying issue which related to actual calls to `require()`. 

I tested re-adding the line to the compiled sass export, and was able to successfully use the altered `sass.dart.js` to compile a Sass file with Webpack.