### PR TITLE
Revert 3c5a2ccf0af48f128596c08a7da4081fbacc2e13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.7.2
+
+* Stop attempting to compile native executables for 32-bit Dart SDKs, again. (I
+  misunderstood and thought the underlying Dart SDK issue was fixed.)
+
 ## 2.7.1
 
 * Make `require` available as a top-level name for JS interop. Dependencies

--- a/lib/src/standalone.dart
+++ b/lib/src/standalone.dart
@@ -164,10 +164,14 @@ void addStandaloneTasks() {
 ///
 /// We can only use the native executable on the current operating system *and*
 /// on 64-bit machines, because currently Dart doesn't support cross-compilation
-/// (dart-lang/sdk#28617).
+/// (dart-lang/sdk#28617) and only 64-bit Dart SDKs support `dart compile exe`
+/// (dart-lang/sdk#47177).
 bool _useNative(String os, String arch) {
   _verifyOsAndArch(os, arch);
-  return _isCurrentOsAndArch(os, arch);
+  if (!_isCurrentOsAndArch(os, arch)) return false;
+  if (arch == "ia32") return false;
+
+  return true;
 }
 
 /// List of strings containing the os and arch for the current Dart SDK.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_pkg
-version: 2.7.1
+version: 2.7.2
 description: Grinder tasks for releasing Dart CLI packages.
 homepage: https://github.com/google/dart_cli_pkg
 


### PR DESCRIPTION
I misread the Dart SDK issue and thought it was fixed, rather than
just resolved to add a better error message.