### PR TITLE
Remove `waitFor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.8.1
+
+* Stop using `dart:cli`.
+
 ## 2.8.0
 
 * Add standalone and GitHub tasks for all OS/architecture combinations supported

--- a/lib/src/template.dart
+++ b/lib/src/template.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// ignore: deprecated_member_use
-import 'dart:cli';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
@@ -29,8 +27,7 @@ final _cache = p.PathMap<String>();
 /// Note: This function only supports simple variable replacement. It does not
 /// support any additional Mustache features.
 String renderTemplate(String path, Map<String, String> variables) {
-  // ignore: deprecated_member_use
-  path = p.join(waitFor(cliPkgSrc), 'templates', path);
+  path = p.join(cliPkgSrc, 'templates', path);
   var text =
       _cache.putIfAbsent(path, () => File("$path.mustache").readAsStringSync());
   for (var entry in variables.entries) {

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -43,10 +43,8 @@ final Version dartVersion = Version.parse(Platform.version.split(" ").first);
 bool get isTesting => Platform.environment["_CLI_PKG_TESTING"] == "true";
 
 /// The `src/` directory in the `cli_pkg` package.
-final Future<String> cliPkgSrc = () async {
-  return p.fromUri(
-      await Isolate.resolvePackageUri(Uri.parse('package:cli_pkg/src')));
-}();
+String get cliPkgSrc =>
+    p.fromUri(Isolate.resolvePackageUriSync(Uri.parse('package:cli_pkg/src')));
 
 /// A shared client to use across all HTTP requests.
 ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_pkg
-version: 2.8.0
+version: 2.8.1
 description: Grinder tasks for releasing Dart CLI packages.
 homepage: https://github.com/google/dart_cli_pkg
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Grinder tasks for releasing Dart CLI packages.
 homepage: https://github.com/google/dart_cli_pkg
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ">=3.2.0 <4.0.0"
 
 dependencies:
   archive: ^3.1.2


### PR DESCRIPTION
Dart 3.3 is released and prints the following error:

> Synchronous waiting using dart:cli waitFor and C API Dart_WaitForEvent is deprecated and disabled by default. This feature will be fully removed in Dart 3.4 release. You can currently still enable it by passing --enable_deprecated_wait_for to the Dart VM. See https://dartbug.com/52121.

This PR removes the usage of `waitFor`, and bump the sdk requirement to `>=3.2.0` for `resolvePackageUriSync`.