### PR TITLE
Add support for android-riscv64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.9.1
+## 2.10.0
 
 * Add standalone and GitHub tasks for android-riscv64.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.9.1
+
+* Add standalone and GitHub tasks for android-riscv64.
+
 ## 2.9.0
 
 * Expand `homebrewEditFormula`'s return type from `String` to

--- a/lib/src/standalone/cli_platform.dart
+++ b/lib/src/standalone/cli_platform.dart
@@ -25,9 +25,6 @@ import 'operating_system.dart';
 /// Certain ABIs that Dart recognizes but cli_pkg doesn't support for various
 /// reasons.
 const _unsupportedAbis = {
-  // The dart-android project doesn't support this because Android on riscv64 is
-  // "still far from stable"
-  Abi.androidRiscv64,
   // This is still experimental and Dart isn't shipping SDKs for it yet
   Abi.linuxRiscv32
 };

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_pkg
-version: 2.9.0
+version: 2.10.0
 description: Grinder tasks for releasing Dart CLI packages.
 homepage: https://github.com/google/dart_cli_pkg
 


### PR DESCRIPTION
The dart-sdk on android-riscv64 seems to be stable enough. We now have a dart-sdk release build for android-riscv64:
https://github.com/dart-android/dart/releases/download/3.3.1/dartsdk-android-riscv64-release.tar.gz

The real problem of android-riscv64 is that the support of riscv64 on the android operating system itself is unstable, and currently only exists as snapshot builds: https://ci.android.com/builds/branches/aosp-main/grid?legacy=1&selected-targets=aosp_cf_riscv64_phone-trunk_staging-userdebug

The lack of a stable OS means it will be difficult to build aot-snapshot, but at least we can build kernel snapshot from a different host architecture. 