### PR TITLE
Add lazy and optional options to JSRequire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.11.0
+
+* Add option `lazy` and `optional` to `JSRequire`.
+
 ## 2.10.0
 
 * Add standalone and GitHub tasks for android-riscv64.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.11.0
 
-* Add option `lazy` and `optional` to `JSRequire`.
+* Add `lazy` and `optional` options to `JSRequire()`.
 
 ## 2.10.0
 

--- a/lib/src/js_require.dart
+++ b/lib/src/js_require.dart
@@ -31,12 +31,29 @@ class JSRequire {
   /// This defaults to a valid JS identifier based on [package].
   final String identifier;
 
+  /// Whether the dependency is loaded lazily or not. When [lazy] is true,
+  /// the dependency is exposed via a lazy getter.
+  ///
+  /// This defaults to false.
+  final bool lazy;
+
+  /// Whether the dependency is optional or not. When [optional] is true,
+  /// failures in requiring the dependency will return null instead of throwing
+  /// an error.
+  ///
+  /// This defaults to false.
+  final bool optional;
+
   /// The target in which to include this require.
   ///
   /// This defaults to [JSRequireTarget.all].
   final JSRequireTarget target;
 
-  JSRequire(this.package, {String? identifier, JSRequireTarget? target})
+  JSRequire(this.package,
+      {String? identifier,
+      JSRequireTarget? target,
+      this.lazy = false,
+      this.optional = false})
       : identifier = identifier ??
             package
                 .replaceFirst(RegExp(r'^@'), '')

--- a/lib/src/js_require.dart
+++ b/lib/src/js_require.dart
@@ -31,15 +31,19 @@ class JSRequire {
   /// This defaults to a valid JS identifier based on [package].
   final String identifier;
 
-  /// Whether the dependency is loaded lazily or not. When [lazy] is true,
-  /// the dependency is exposed via a lazy getter.
+  /// Whether the dependency is loaded lazily.
+  ///
+  /// A lazy-loaded dependency only executes the `require()` function the first
+  /// time the module identifier is referenced, rather than eagerly executing it
+  /// when this package is loaded.
   ///
   /// This defaults to false.
   final bool lazy;
 
-  /// Whether the dependency is optional or not. When [optional] is true,
-  /// failures in requiring the dependency will return null instead of throwing
-  /// an error.
+  /// Whether the dependency is optional.
+  ///
+  /// An optional dependency's module identifier will be `null` if a load fails
+  /// rather than throwing an error.
   ///
   /// This defaults to false.
   final bool optional;

--- a/lib/src/npm.dart
+++ b/lib/src/npm.dart
@@ -556,8 +556,8 @@ if (typeof exports !== "undefined") {
 }""", "self.exports = _cliPkgExportParam || $exportsVariable;"));
 
   for (var require in [...jsRequires.value, ...extractedRequires]) {
-    // A lazy require creates a function that invokes `require`, create a lazy
-    // getter to invoke the function.
+    // Rather than defining a module directly, a lazy require defines a function
+    // that loads a module, so we need to expose those functions as getters.
     if (require.lazy) {
       buffer.writeln("Object.defineProperty(self, '${require.identifier}', "
           "{ get: _cliPkgRequires.${require.identifier} });");
@@ -638,7 +638,7 @@ String _loadRequires(JSRequireSet requires) {
   var buffer = StringBuffer("library.load({");
   if (requires.isNotEmpty) buffer.writeln();
   for (var require in requires) {
-    // Returns a function for lazy requires, which will be called by lazy getter
+    // The functions returned by lazy requires will be wrapped in getters.
     var requireFn = switch (require) {
       JSRequire(lazy: true, optional: true) => "(function(i){"
           "let r;"

--- a/lib/src/npm.dart
+++ b/lib/src/npm.dart
@@ -556,8 +556,15 @@ if (typeof exports !== "undefined") {
 }""", "self.exports = _cliPkgExportParam || $exportsVariable;"));
 
   for (var require in [...jsRequires.value, ...extractedRequires]) {
-    buffer.write("self.${require.identifier} = ");
-    buffer.writeln("_cliPkgRequires.${require.identifier};");
+    // A lazy require creates a function that invokes `require`, create a lazy
+    // getter to invoke the function.
+    if (require.lazy) {
+      buffer.writeln("Object.defineProperty(self, '${require.identifier}', "
+          "{ get: _cliPkgRequires.${require.identifier} });");
+    } else {
+      buffer.writeln("self.${require.identifier} = "
+          "_cliPkgRequires.${require.identifier};");
+    }
   }
 
   buffer.write(compiledDart);
@@ -631,8 +638,29 @@ String _loadRequires(JSRequireSet requires) {
   var buffer = StringBuffer("library.load({");
   if (requires.isNotEmpty) buffer.writeln();
   for (var require in requires) {
+    // Returns a function for lazy requires, which will be called by lazy getter
+    var requireFn = switch (require) {
+      JSRequire(lazy: true, optional: true) => "(function(i){"
+          "let r;"
+          "return function ${require.identifier}(){"
+          "if(void 0!==r)return r;"
+          "try{r=require(i)}catch(e){if('MODULE_NOT_FOUND'!==e.code)console.error(e);r=null}"
+          "return r"
+          "}"
+          "})",
+      JSRequire(lazy: true) => "(function(i){"
+          "return function ${require.identifier}(){"
+          "return require(i)"
+          "}"
+          "})",
+      JSRequire(optional: true) => "(function(i){"
+          "try{return require(i)}catch(e){if('MODULE_NOT_FOUND'!==e.code)console.error(e);return null}"
+          "})",
+      _ => "require"
+    };
+
     buffer.writeln(
-        "  ${require.identifier}: require(${json.encode(require.package)}),");
+        "  ${require.identifier}: $requireFn(${json.encode(require.package)}),");
   }
   buffer.writeln("});");
   return buffer.toString();

--- a/lib/src/npm.dart
+++ b/lib/src/npm.dart
@@ -644,7 +644,12 @@ String _loadRequires(JSRequireSet requires) {
           "let r;"
           "return function ${require.identifier}(){"
           "if(void 0!==r)return r;"
-          "try{r=require(i)}catch(e){if('MODULE_NOT_FOUND'!==e.code)console.error(e);r=null}"
+          "try{"
+          "r=require(i)"
+          "}catch(e){"
+          "if('MODULE_NOT_FOUND'!==e.code)console.error(e);"
+          "r=null"
+          "}"
           "return r"
           "}"
           "})",
@@ -654,7 +659,12 @@ String _loadRequires(JSRequireSet requires) {
           "}"
           "})",
       JSRequire(optional: true) => "(function(i){"
-          "try{return require(i)}catch(e){if('MODULE_NOT_FOUND'!==e.code)console.error(e);return null}"
+          "try{"
+          "return require(i)"
+          "}catch(e){"
+          "if('MODULE_NOT_FOUND'!==e.code)console.error(e);"
+          "return null"
+          "}"
           "})",
       _ => "require"
     };

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_pkg
-version: 2.10.0
+version: 2.11.0
 description: Grinder tasks for releasing Dart CLI packages.
 homepage: https://github.com/google/dart_cli_pkg
 

--- a/test/npm_test.dart
+++ b/test/npm_test.dart
@@ -1201,6 +1201,253 @@ void main() {
       expect(process.stdout, emitsInOrder(["true", emitsDone]));
       expect(process.shouldExit(0), completes);
     });
+
+    group("lazy and optional require()s", () {
+      /// Determines whether a package that declares a `pkg.JSRequire` on the
+      /// specified package has access to that package when loaded as a Node library.
+      Future<bool> load(
+          String requireDeclarations, String dartExports, String js) async {
+        await d.package(pubspec, """
+          void main(List<String> args) {
+            pkg.jsModuleMainLibrary.value = "lib/src/exports.dart";
+            pkg.jsRequires.value = [$requireDeclarations];
+
+            pkg.addNpmTasks();
+            grind(args);
+          }
+        """, [
+          _packageJson,
+          d.dir("lib/src", [d.file("exports.dart", dartExports)])
+        ]).create();
+
+        await (await grind(["pkg-npm-dev"])).shouldExit();
+
+        await d.dir("depender", [
+          d.file(
+              "package.json",
+              json.encode({
+                "dependencies": {"my_app": "file:../my_app/build/npm"}
+              })),
+          d.file("test.js", js)
+        ]).create();
+
+        await (await TestProcess.start("npm", ["install"],
+                runInShell: true, workingDirectory: d.path("depender")))
+            .shouldExit(0);
+
+        var process = await TestProcess.start(
+            "node$dotExe", [d.path("depender/test.js")]);
+        var result = (await process.stdout.next) == "true";
+        await process.shouldExit(0);
+        return result;
+      }
+
+      test("have access to lazy requires", () async {
+        expect(
+            load(
+                "pkg.JSRequire('os', target: pkg.JSRequireTarget.node),"
+                    "pkg.JSRequire('os', target: pkg.JSRequireTarget.node, lazy: true, identifier: 'os_lazy')",
+                """
+import 'package:js/js.dart';
+
+@JS()
+class Exports {
+  external set os(Object? value);
+  external set osLazy(Object? value);
+}
+
+@JS()
+external Exports get exports;
+
+@JS('os')
+external Object? os;
+
+@JS('os_lazy')
+external Object? get osLazy;
+
+void main() {
+  exports.os = os;
+  exports.osLazy = osLazy;
+}
+""",
+                """
+var my_app = require("my_app");
+
+console.log(my_app.os === my_app.osLazy);
+"""),
+            completion(isTrue));
+      });
+
+      test("throw lazily for access to non-exist lazy require()", () async {
+        expect(
+            load(
+                "pkg.JSRequire('module_not_found', target: pkg.JSRequireTarget.node, lazy: true)",
+                """
+import 'package:js/js.dart';
+import 'package:js/js_util.dart';
+
+@JS()
+class Exports {
+  external set run(Object? value);
+}
+
+@JS()
+external Exports get exports;
+
+@JS('module_not_found')
+external Object? get moduleNotFound;
+
+void main() {
+  exports.run = allowInterop(() => moduleNotFound);
+}
+""",
+                """
+var my_app = require("my_app");
+
+try {
+  myapp.run()
+} catch (_) {
+  console.log(true)
+}
+"""),
+            completion(isTrue));
+      });
+
+      test("have access to optional requires", () async {
+        expect(
+            load(
+                "pkg.JSRequire('os', target: pkg.JSRequireTarget.node),"
+                    "pkg.JSRequire('os', target: pkg.JSRequireTarget.node, optional: true, identifier: 'os_optional')",
+                """
+import 'package:js/js.dart';
+
+@JS()
+class Exports {
+  external set os(Object? value);
+  external set osOptional(Object? value);
+}
+
+@JS()
+external Exports get exports;
+
+@JS('os')
+external Object? os;
+
+@JS('os_optional')
+external Object? osOptional;
+
+void main() {
+  exports.os = os;
+  exports.osOptional = osOptional;
+}
+""",
+                """
+var my_app = require("my_app");
+
+console.log(my_app.os === my_app.osOptional);
+"""),
+            completion(isTrue));
+      });
+
+      test("return null for access to non-exist optional require()", () async {
+        expect(
+            load(
+                "pkg.JSRequire('module_not_found', target: pkg.JSRequireTarget.node, optional: true)",
+                """
+import 'package:js/js.dart';
+import 'package:js/js_util.dart';
+
+@JS()
+class Exports {
+  external set moduleNotFound(Object? value);
+}
+
+@JS()
+external Exports get exports;
+
+@JS('module_not_found')
+external Object? moduleNotFound;
+
+void main() {
+  exports.moduleNotFound = moduleNotFound;
+}
+""",
+                """
+var my_app = require("my_app");
+
+console.log(my_app.moduleNotFound === null)
+"""),
+            completion(isTrue));
+      });
+
+      test("have access to lazy optional requires", () async {
+        expect(
+            load(
+                "pkg.JSRequire('os', target: pkg.JSRequireTarget.node),"
+                    "pkg.JSRequire('os', target: pkg.JSRequireTarget.node, lazy: true, optional: true, identifier: 'os_lazy_optional')",
+                """
+import 'package:js/js.dart';
+
+@JS()
+class Exports {
+  external set os(Object? value);
+  external set osLazyOptional(Object? value);
+}
+
+@JS()
+external Exports get exports;
+
+@JS('os')
+external Object? os;
+
+@JS('os_lazy_optional')
+external Object? get osLazyOptional;
+
+void main() {
+  exports.os = os;
+  exports.osLazyOptional = osLazyOptional;
+}
+""",
+                """
+var my_app = require("my_app");
+
+console.log(my_app.os === my_app.osLazyOptional);
+"""),
+            completion(isTrue));
+      });
+
+      test("return null lazily for access to non-exist lazy optional require()",
+          () async {
+        expect(
+            load(
+                "pkg.JSRequire('module_not_found', target: pkg.JSRequireTarget.node, lazy: true, optional: true)",
+                """
+import 'package:js/js.dart';
+import 'package:js/js_util.dart';
+
+@JS()
+class Exports {
+  external set run(Object? value);
+}
+
+@JS()
+external Exports get exports;
+
+@JS('module_not_found')
+external Object? get moduleNotFound;
+
+void main() {
+  exports.run = allowInterop(() => moduleNotFound);
+}
+""",
+                """
+var my_app = require("my_app");
+
+console.log(my_app.run() === null)
+"""),
+            completion(isTrue));
+      });
+    });
   });
 }
 

--- a/test/npm_test.dart
+++ b/test/npm_test.dart
@@ -1245,138 +1245,143 @@ void main() {
       test("have access to lazy requires", () async {
         expect(
             load(
-                "pkg.JSRequire('os', target: pkg.JSRequireTarget.node),"
-                    "pkg.JSRequire('os', target: pkg.JSRequireTarget.node, lazy: true, identifier: 'os_lazy')",
+                "pkg.JSRequire('os', target: pkg.JSRequireTarget.node), "
+                    "pkg.JSRequire('os', target: pkg.JSRequireTarget.node, "
+                    "lazy: true, identifier: 'os_lazy')",
                 """
-import 'package:js/js.dart';
+                  import 'package:js/js.dart';
 
-@JS()
-class Exports {
-  external set os(Object? value);
-  external set osLazy(Object? value);
-}
+                  @JS()
+                  class Exports {
+                    external set os(Object? value);
+                    external set osLazy(Object? value);
+                  }
 
-@JS()
-external Exports get exports;
+                  @JS()
+                  external Exports get exports;
 
-@JS('os')
-external Object? os;
+                  @JS('os')
+                  external Object? os;
 
-@JS('os_lazy')
-external Object? get osLazy;
+                  @JS('os_lazy')
+                  external Object? get osLazy;
 
-void main() {
-  exports.os = os;
-  exports.osLazy = osLazy;
-}
-""",
+                  void main() {
+                    exports.os = os;
+                    exports.osLazy = osLazy;
+                  }
+                  """,
                 """
-var my_app = require("my_app");
+                  var my_app = require("my_app");
 
-console.log(my_app.os === my_app.osLazy);
-"""),
+                  console.log(my_app.os === my_app.osLazy);
+                """),
             completion(isTrue));
       });
 
       test("throw lazily for access to non-exist lazy require()", () async {
         expect(
             load(
-                "pkg.JSRequire('module_not_found', target: pkg.JSRequireTarget.node, lazy: true)",
+                "pkg.JSRequire('module_not_found', "
+                    "target: pkg.JSRequireTarget.node, lazy: true)",
                 """
-import 'package:js/js.dart';
-import 'package:js/js_util.dart';
+                  import 'package:js/js.dart';
+                  import 'package:js/js_util.dart';
 
-@JS()
-class Exports {
-  external set run(Object? value);
-}
+                  @JS()
+                  class Exports {
+                    external set run(Object? value);
+                  }
 
-@JS()
-external Exports get exports;
+                  @JS()
+                  external Exports get exports;
 
-@JS('module_not_found')
-external Object? get moduleNotFound;
+                  @JS('module_not_found')
+                  external Object? get moduleNotFound;
 
-void main() {
-  exports.run = allowInterop(() => moduleNotFound);
-}
-""",
+                  void main() {
+                    exports.run = allowInterop(() => moduleNotFound);
+                  }
+                  """,
                 """
-var my_app = require("my_app");
+                  var my_app = require("my_app");
 
-try {
-  myapp.run()
-} catch (_) {
-  console.log(true)
-}
-"""),
+                  try {
+                    myapp.run()
+                  } catch (_) {
+                    console.log(true)
+                  }
+                """),
             completion(isTrue));
       });
 
       test("have access to optional requires", () async {
         expect(
             load(
-                "pkg.JSRequire('os', target: pkg.JSRequireTarget.node),"
-                    "pkg.JSRequire('os', target: pkg.JSRequireTarget.node, optional: true, identifier: 'os_optional')",
+                "pkg.JSRequire('os', target: pkg.JSRequireTarget.node), "
+                    "pkg.JSRequire('os', target: pkg.JSRequireTarget.node, "
+                    "optional: true, identifier: 'os_optional')",
                 """
-import 'package:js/js.dart';
+                  import 'package:js/js.dart';
 
-@JS()
-class Exports {
-  external set os(Object? value);
-  external set osOptional(Object? value);
-}
+                  @JS()
+                  class Exports {
+                    external set os(Object? value);
+                    external set osOptional(Object? value);
+                  }
 
-@JS()
-external Exports get exports;
+                  @JS()
+                  external Exports get exports;
 
-@JS('os')
-external Object? os;
+                  @JS('os')
+                  external Object? os;
 
-@JS('os_optional')
-external Object? osOptional;
+                  @JS('os_optional')
+                  external Object? osOptional;
 
-void main() {
-  exports.os = os;
-  exports.osOptional = osOptional;
-}
-""",
+                  void main() {
+                    exports.os = os;
+                    exports.osOptional = osOptional;
+                  }
+                """,
                 """
-var my_app = require("my_app");
+                  var my_app = require("my_app");
 
-console.log(my_app.os === my_app.osOptional);
-"""),
+                  console.log(my_app.os === my_app.osOptional);
+                """),
             completion(isTrue));
       });
 
-      test("return null for access to non-exist optional require()", () async {
+      test("return null for access to non-existant optional require()",
+          () async {
         expect(
             load(
-                "pkg.JSRequire('module_not_found', target: pkg.JSRequireTarget.node, optional: true)",
+                "pkg.JSRequire('module_not_found', "
+                    "target: pkg.JSRequireTarget.node, optional: true)",
                 """
-import 'package:js/js.dart';
-import 'package:js/js_util.dart';
+                  import 'package:js/js.dart';
+                  import 'package:js/js_util.dart';
 
-@JS()
-class Exports {
-  external set moduleNotFound(Object? value);
-}
+                  @JS()
+                  class Exports {
+                    external set moduleNotFound(Object? value);
+                  }
 
-@JS()
-external Exports get exports;
+                  @JS()
+                  external Exports get exports;
 
-@JS('module_not_found')
-external Object? moduleNotFound;
+                  @JS('module_not_found')
+                  external Object? moduleNotFound;
 
-void main() {
-  exports.moduleNotFound = moduleNotFound;
-}
-""",
+                  void main() {
+                    exports.moduleNotFound = moduleNotFound;
+                  }
+                  """,
                 """
-var my_app = require("my_app");
+                  var my_app = require("my_app");
 
-console.log(my_app.moduleNotFound === null)
-"""),
+                  console.log(my_app.moduleNotFound === null)
+                """),
             completion(isTrue));
       });
 
@@ -1384,67 +1389,72 @@ console.log(my_app.moduleNotFound === null)
         expect(
             load(
                 "pkg.JSRequire('os', target: pkg.JSRequireTarget.node),"
-                    "pkg.JSRequire('os', target: pkg.JSRequireTarget.node, lazy: true, optional: true, identifier: 'os_lazy_optional')",
+                    "pkg.JSRequire('os', target: pkg.JSRequireTarget.node, "
+                    "lazy: true, optional: true, "
+                    "identifier: 'os_lazy_optional')",
                 """
-import 'package:js/js.dart';
+                  import 'package:js/js.dart';
 
-@JS()
-class Exports {
-  external set os(Object? value);
-  external set osLazyOptional(Object? value);
-}
+                  @JS()
+                  class Exports {
+                    external set os(Object? value);
+                    external set osLazyOptional(Object? value);
+                  }
 
-@JS()
-external Exports get exports;
+                  @JS()
+                  external Exports get exports;
 
-@JS('os')
-external Object? os;
+                  @JS('os')
+                  external Object? os;
 
-@JS('os_lazy_optional')
-external Object? get osLazyOptional;
+                  @JS('os_lazy_optional')
+                  external Object? get osLazyOptional;
 
-void main() {
-  exports.os = os;
-  exports.osLazyOptional = osLazyOptional;
-}
-""",
+                  void main() {
+                    exports.os = os;
+                    exports.osLazyOptional = osLazyOptional;
+                  }
+                """,
                 """
-var my_app = require("my_app");
+                  var my_app = require("my_app");
 
-console.log(my_app.os === my_app.osLazyOptional);
-"""),
+                  console.log(my_app.os === my_app.osLazyOptional);
+                """),
             completion(isTrue));
       });
 
-      test("return null lazily for access to non-exist lazy optional require()",
-          () async {
+      test(
+          "return null lazily for access to non-existant lazy optional "
+          "require()", () async {
         expect(
             load(
-                "pkg.JSRequire('module_not_found', target: pkg.JSRequireTarget.node, lazy: true, optional: true)",
+                "pkg.JSRequire('module_not_found', "
+                    "target: pkg.JSRequireTarget.node, lazy: true, "
+                    "optional: true)",
                 """
-import 'package:js/js.dart';
-import 'package:js/js_util.dart';
+                  import 'package:js/js.dart';
+                  import 'package:js/js_util.dart';
 
-@JS()
-class Exports {
-  external set run(Object? value);
-}
+                  @JS()
+                  class Exports {
+                    external set run(Object? value);
+                  }
 
-@JS()
-external Exports get exports;
+                  @JS()
+                  external Exports get exports;
 
-@JS('module_not_found')
-external Object? get moduleNotFound;
+                  @JS('module_not_found')
+                  external Object? get moduleNotFound;
 
-void main() {
-  exports.run = allowInterop(() => moduleNotFound);
-}
-""",
+                  void main() {
+                    exports.run = allowInterop(() => moduleNotFound);
+                  }
+                """,
                 """
-var my_app = require("my_app");
+                  var my_app = require("my_app");
 
-console.log(my_app.run() === null)
-"""),
+                  console.log(my_app.run() === null)
+                """),
             completion(isTrue));
       });
     });


### PR DESCRIPTION
This PR is extracted from https://github.com/sass/dart-sass/pull/2414 to make it more general.

For example, with an optional lazy we can define an external getter in Dart, which maps to a lazy getter in JS. The `require()` is only called when getter is actually used.

``` dart
@JS('parcel_watcher')
external JSObject? get parcelWatcher;
```

Generated lazy and optional dependency code looks like this:


``` js
// sass.js

library.load({
  parcel_watcher: (function(i){let r;return function parcel_watcher(){if(void 0!==r)return r;try{r=require(i)}catch(e){if('MODULE_NOT_FOUND'!==e.code)console.error(e);r=null}return r}})("@parcel/watcher"),
});
```

``` js
// sass.dart.js

Object.defineProperty(self, 'parcel_watcher', { get: _cliPkgRequires.parcel_watcher });
``` 