### PR TITLE
Migrate to v4 of `package:archive`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
-## 2.16.0-wip
+## 2.15.1
 
-* Update to v4 of `package:archive`,
-  increasing the dependency constraint to `^4.0.6` from `^3.1.2`.
+* Expand and upgrade some dependency versions.
 
 ## 2.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.16.0-wip
+
+* Update to v4 of `package:archive`,
+  increasing the dependency constraint to `^4.0.6` from `^3.1.2`.
+
 ## 2.15.0
 
 * Allow `pkg.npmToken` to be null. This causes npm deployment to use the system

--- a/lib/src/github.dart
+++ b/lib/src/github.dart
@@ -392,7 +392,7 @@ Future<void> _fixPermissions() async {
               await _uploadToRelease(
                 release,
                 archiveName,
-                GZipEncoder().encode(TarEncoder().encode(archive))!,
+                GZipEncoder().encodeBytes(TarEncoder().encodeBytes(archive)),
               );
               print("Fixed $archiveName");
             },

--- a/lib/src/github.dart
+++ b/lib/src/github.dart
@@ -358,13 +358,17 @@ Future<void> _fixPermissions() async {
                 );
               }
 
-              var archive = TarDecoder().decodeBytes(
+              var originalArchive = TarDecoder().decodeBytes(
                 GZipDecoder().decodeBytes(getResponse.bodyBytes),
               );
-              for (var file in archive.files) {
+              var fixedArchive = Archive();
+              for (var file in originalArchive.files) {
                 // 0o755: ensure that the write permission bits aren't set for
                 // non-owners.
-                file.mode &= 493;
+                fixedArchive.add(
+                  ArchiveFile.bytes(file.name, file.content)
+                    ..mode = file.mode & 493, // 0o755
+                );
               }
 
               var deleteResponse = await client.delete(
@@ -392,7 +396,9 @@ Future<void> _fixPermissions() async {
               await _uploadToRelease(
                 release,
                 archiveName,
-                GZipEncoder().encodeBytes(TarEncoder().encodeBytes(archive)),
+                GZipEncoder().encodeBytes(
+                  TarEncoder().encodeBytes(fixedArchive),
+                ),
               );
               print("Fixed $archiveName");
             },

--- a/lib/src/standalone.dart
+++ b/lib/src/standalone.dart
@@ -276,17 +276,17 @@ Future<void> _buildPackage(CliPlatform platform) async {
   if (platform.os.isWindows) {
     var output = "$prefix.zip";
     log("Creating $output...");
-    File(output).writeAsBytesSync(ZipEncoder().encode(archive)!);
+    File(output).writeAsBytesSync(ZipEncoder().encodeBytes(archive));
   } else {
     var output = "$prefix.tar.gz";
     log("Creating $output...");
-    File(
-      output,
-    ).writeAsBytesSync(GZipEncoder().encode(TarEncoder().encode(archive))!);
+    File(output).writeAsBytesSync(
+      GZipEncoder().encodeBytes(TarEncoder().encodeBytes(archive)),
+    );
   }
 }
 
-/// Returns the binary contents of the `dart` or `dartaotruntime` exectuable for
+/// Returns the binary contents of the `dart` or `dartaotruntime` executable for
 /// the given [platform].
 Future<List<int>> _dartExecutable(CliPlatform platform) async {
   // If we're building for the same SDK we're using, load its executable from
@@ -336,11 +336,10 @@ Future<List<int>> _dartExecutable(CliPlatform platform) async {
   var dartvm = dartVersion >= Version(3, 10, 0, pre: '0') ? 'dartvm' : 'dart';
   var filename = "/bin/$dartvm${platform.binaryExtension}";
   return (url.endsWith(".zip")
-              ? ZipDecoder().decodeBytes(response.bodyBytes)
-              : TarDecoder().decodeBytes(
-                  GZipDecoder().decodeBytes(response.bodyBytes),
-                ))
-          .firstWhere((file) => file.name.endsWith(filename))
-          .content
-      as List<int>;
+          ? ZipDecoder().decodeBytes(response.bodyBytes)
+          : TarDecoder().decodeBytes(
+              GZipDecoder().decodeBytes(response.bodyBytes),
+            ))
+      .firstWhere((file) => file.name.endsWith(filename))
+      .content;
 }

--- a/lib/src/standalone.dart
+++ b/lib/src/standalone.dart
@@ -222,12 +222,12 @@ Future<void> _buildDev() async {
 /// Builds a package for the given [platform].
 Future<void> _buildPackage(CliPlatform platform) async {
   var archive = Archive()
-    ..addFile(fileFromString("$standaloneName/src/LICENSE", await license));
+    ..add(fileFromString("$standaloneName/src/LICENSE", await license));
 
   var nativeExe = useExe.value(platform);
 
   if (!(platform.useNative && nativeExe)) {
-    archive.addFile(
+    archive.add(
       fileFromBytes(
         "$standaloneName/src/dart${platform.binaryExtension}",
         await _dartExecutable(platform),
@@ -238,7 +238,7 @@ Future<void> _buildPackage(CliPlatform platform) async {
 
   for (var name in executables.value.keys) {
     if (platform.useNative && nativeExe) {
-      archive.addFile(
+      archive.add(
         file(
           "$standaloneName/$name${platform.binaryExtension}",
           "build/$name.native",
@@ -246,7 +246,7 @@ Future<void> _buildPackage(CliPlatform platform) async {
         ),
       );
     } else {
-      archive.addFile(
+      archive.add(
         file(
           "$standaloneName/src/$name.snapshot",
           platform.useNative ? "build/$name.native" : "build/$name.snapshot",
@@ -259,7 +259,7 @@ Future<void> _buildPackage(CliPlatform platform) async {
     // Do this separately from adding entrypoints because multiple executables
     // may have the same entrypoint.
     for (var name in executables.value.keys) {
-      archive.addFile(
+      archive.add(
         fileFromString(
           "$standaloneName/$name${platform.os.isWindows ? '.bat' : ''}",
           renderTemplate(

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -165,7 +165,7 @@ ArchiveFile fileFromBytes(
   String path,
   List<int> data, {
   bool executable = false,
-}) => ArchiveFile(path, data.length, data)
+}) => ArchiveFile.bytes(path, data)
   ..mode = executable ? 493 : 420
   ..lastModTime = DateTime.now().millisecondsSinceEpoch ~/ 1000;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
-  archive: ^3.1.2
+  archive: ^4.0.6
   async: ^2.5.0
   charcode: ^1.2.0
   cli_util: ^0.4.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_pkg
-version: 2.16.0-wip
+version: 2.15.1
 description: Grinder tasks for releasing Dart CLI packages.
 homepage: https://github.com/google/dart_cli_pkg
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_pkg
-version: 2.15.0
+version: 2.16.0-wip
 description: Grinder tasks for releasing Dart CLI packages.
 homepage: https://github.com/google/dart_cli_pkg
 

--- a/test/descriptor/archive.dart
+++ b/test/descriptor/archive.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:archive/archive.dart';
 import 'package:async/async.dart';
@@ -101,7 +102,7 @@ class ArchiveDescriptor extends Descriptor implements FileDescriptor {
   }());
 
   Future<void> validate([String? parent]) async {
-    // Access this first so we eaerly throw an error for a path with an invalid
+    // Access this first so we eagerly throw an error for a path with an invalid
     // extension.
     var decoder = _decodeFunction();
 
@@ -131,7 +132,7 @@ class ArchiveDescriptor extends Descriptor implements FileDescriptor {
         archive.files.map((file) async {
           var path = p.join(tempDir, file.name);
           await Directory(p.dirname(path)).create(recursive: true);
-          await File(path).writeAsBytes(file.content as List<int>);
+          await File(path).writeAsBytes(file.content);
         }),
       );
 
@@ -155,15 +156,17 @@ class ArchiveDescriptor extends Descriptor implements FileDescriptor {
   /// [name].
   List<int> Function(Archive) _encodeFunction() {
     if (name.endsWith('.zip')) {
-      return (archive) => ZipEncoder().encode(archive)!;
+      return ZipEncoder().encodeBytes;
     } else if (name.endsWith('.tar')) {
-      return TarEncoder().encode;
+      return TarEncoder().encodeBytes;
     } else if (name.endsWith('.tar.gz') ||
         name.endsWith('.tar.gzip') ||
         name.endsWith('.tgz')) {
-      return (archive) => GZipEncoder().encode(TarEncoder().encode(archive))!;
+      return (archive) =>
+          GZipEncoder().encodeBytes(TarEncoder().encodeBytes(archive));
     } else if (name.endsWith('.tar.bz2') || name.endsWith('.tar.bzip2')) {
-      return (archive) => BZip2Encoder().encode(TarEncoder().encode(archive));
+      return (archive) =>
+          BZip2Encoder().encodeBytes(TarEncoder().encodeBytes(archive));
     } else {
       throw UnsupportedError('Unknown file format $name.');
     }
@@ -171,7 +174,7 @@ class ArchiveDescriptor extends Descriptor implements FileDescriptor {
 
   /// Returns the function to use to decode this file from binary, based on its
   /// [name].
-  Archive Function(List<int>) _decodeFunction() {
+  Archive Function(Uint8List) _decodeFunction() {
     if (name.endsWith('.zip')) {
       return ZipDecoder().decodeBytes;
     } else if (name.endsWith('.tar')) {

--- a/test/descriptor/archive.dart
+++ b/test/descriptor/archive.dart
@@ -34,7 +34,7 @@ class ArchiveDescriptor extends Descriptor implements FileDescriptor {
   /// this file.
   Future<Archive> get archive async {
     var archive = Archive();
-    (await _files(contents)).forEach(archive.addFile);
+    (await _files(contents)).forEach(archive.add);
     return archive;
   }
 

--- a/test/github_test.dart
+++ b/test/github_test.dart
@@ -551,8 +551,8 @@ void main() {
       "GET",
       "/assets/1/download/tar",
       (request) => shelf.Response.ok(
-        GZipEncoder().encode(
-          TarEncoder().encode(
+        GZipEncoder().encodeBytes(
+          TarEncoder().encodeBytes(
             Archive()
               ..addFile(fileFromString("foo", "foo contents")..mode = 495)
               ..addFile(fileFromString("bar", "bar contents")..mode = 506),

--- a/test/github_test.dart
+++ b/test/github_test.dart
@@ -553,8 +553,8 @@ void main() {
         GZipEncoder().encodeBytes(
           TarEncoder().encodeBytes(
             Archive()
-              ..addFile(fileFromString("foo", "foo contents")..mode = 495)
-              ..addFile(fileFromString("bar", "bar contents")..mode = 506),
+              ..add(fileFromString("foo", "foo contents")..mode = 495)
+              ..add(fileFromString("bar", "bar contents")..mode = 506),
           ),
         ),
       ),

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -91,7 +91,7 @@ Future<void> extract(String path, String destination) async {
   for (var file in archive.files) {
     var filePath = p.join(d.path(destination), file.name);
     Directory(p.dirname(filePath)).createSync(recursive: true);
-    File(filePath).writeAsBytesSync(file.content as List<int>);
+    File(filePath).writeAsBytesSync(file.content);
 
     // Mark the file executable if necessary.
     if (!Platform.isWindows && file.mode & 1 == 1) {


### PR DESCRIPTION
This allows Dart apps and packages that depend on `package:sass` to migrate to the newer, supported version.