### PR TITLE
Fix browser tests by importing the shared tests instead of exporting

### DIFF
--- a/browser_library_test/package-lock.json
+++ b/browser_library_test/package-lock.json
@@ -25,7 +25,7 @@
     },
     "build/npm": {
       "name": "cli-pkg-test",
-      "version": "0.0.1",
+      "version": "0.0.0",
       "dev": true,
       "dependencies": {
         "immutable": "^4.2.0",

--- a/browser_library_test/test/esbuild_import_test.dart
+++ b/browser_library_test/test/esbuild_import_test.dart
@@ -17,4 +17,8 @@ library;
 
 import 'package:test/test.dart';
 
-export 'browser_test_shared.dart';
+import 'browser_test_shared.dart' as shared_browser_tests;
+
+void main() {
+  shared_browser_tests.main();
+}

--- a/browser_library_test/test/esbuild_require_test.dart
+++ b/browser_library_test/test/esbuild_require_test.dart
@@ -17,4 +17,8 @@ library;
 
 import 'package:test/test.dart';
 
-export 'browser_test_shared.dart';
+import 'browser_test_shared.dart' as shared_browser_tests;
+
+void main() {
+  shared_browser_tests.main();
+}

--- a/browser_library_test/test/jspm_test.dart
+++ b/browser_library_test/test/jspm_test.dart
@@ -17,4 +17,8 @@ library;
 
 import 'package:test/test.dart';
 
-export 'browser_test_shared.dart';
+import 'browser_test_shared.dart' as shared_browser_tests;
+
+void main() {
+  shared_browser_tests.main();
+}

--- a/browser_library_test/test/rollup_import_test.dart
+++ b/browser_library_test/test/rollup_import_test.dart
@@ -17,4 +17,8 @@ library;
 
 import 'package:test/test.dart';
 
-export 'browser_test_shared.dart';
+import 'browser_test_shared.dart' as shared_browser_tests;
+
+void main() {
+  shared_browser_tests.main();
+}

--- a/browser_library_test/test/rollup_require_test.dart
+++ b/browser_library_test/test/rollup_require_test.dart
@@ -17,4 +17,8 @@ library;
 
 import 'package:test/test.dart';
 
-export 'browser_test_shared.dart';
+import 'browser_test_shared.dart' as shared_browser_tests;
+
+void main() {
+  shared_browser_tests.main();
+}

--- a/browser_library_test/test/vite_test.dart
+++ b/browser_library_test/test/vite_test.dart
@@ -17,4 +17,8 @@ library;
 
 import 'package:test/test.dart';
 
-export 'browser_test_shared.dart';
+import 'browser_test_shared.dart' as shared_browser_tests;
+
+void main() {
+  shared_browser_tests.main();
+}

--- a/browser_library_test/test/webpack_import_test.dart
+++ b/browser_library_test/test/webpack_import_test.dart
@@ -17,4 +17,8 @@ library;
 
 import 'package:test/test.dart';
 
-export 'browser_test_shared.dart';
+import 'browser_test_shared.dart' as shared_browser_tests;
+
+void main() {
+  shared_browser_tests.main();
+}

--- a/browser_library_test/test/webpack_require_test.dart
+++ b/browser_library_test/test/webpack_require_test.dart
@@ -17,4 +17,8 @@ library;
 
 import 'package:test/test.dart';
 
-export 'browser_test_shared.dart';
+import 'browser_test_shared.dart' as shared_browser_tests;
+
+void main() {
+  shared_browser_tests.main();
+}


### PR DESCRIPTION
Previously we called 'export' to append main() into the test file. Dart Test package 1.29.0 now disallows this pattern. TIL that the test package is released separate from the main Dart binary!

Fixes #195