### PR TITLE
Support latest `package:cli_util` versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.15.2
+
+- Support `cli_util` versions `0.5.x`.
+
 ## 2.15.1
 
 * Expand and upgrade some dependency versions.

--- a/browser_library_test/pubspec.yaml
+++ b/browser_library_test/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 
 dependencies:
   js: ^0.6.3
-  grinder: ^0.9.0
+  grinder: ">=0.9.0 <0.11.0"
   cli_pkg: {path: ..}
   test: ^1.16.7
 dev_dependencies:

--- a/lib/src/pub.dart
+++ b/lib/src/pub.dart
@@ -38,7 +38,7 @@ final String _credentialsPath = () {
   // This follows the same logic as pub.
   if (dartVersion >= Version.parse('2.15.0')) {
     // https://github.com/dart-lang/pub/blob/a16763a93b5050c6a9d917fca5a132cfcb00f1a9/doc/cache_layout.md#layout
-    return p.join(applicationConfigHome('dart'), 'pub-credentials.json');
+    return p.join(BaseDirectories('dart').configHome, 'pub-credentials.json');
   }
 
   // https://github.com/dart-lang/pub/blob/d99b0d58f4059d7bb4ac4616fd3d54ec00a2b5d4/lib/src/system_cache.dart#L34-L43

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   archive: ^4.0.6
   async: ^2.5.0
   charcode: ^1.2.0
-  cli_util: '>=0.4.0 <0.6.0'
+  cli_util: ^0.5.0
   collection: ^1.15.0
   crypto: ^3.0.0
   glob: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   collection: ^1.15.0
   crypto: ^3.0.0
   glob: ^2.0.0
-  grinder: ^0.9.0
+  grinder: ">=0.9.0 <0.11.0"
   http: ">=0.13.0 <2.0.0"
   js: ^0.6.3
   meta: ^1.3.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_pkg
-version: 2.15.1
+version: 2.15.2
 description: Grinder tasks for releasing Dart CLI packages.
 homepage: https://github.com/google/dart_cli_pkg
 
@@ -10,7 +10,7 @@ dependencies:
   archive: ^4.0.6
   async: ^2.5.0
   charcode: ^1.2.0
-  cli_util: ^0.4.0
+  cli_util: '>=0.4.0 <0.6.0'
   collection: ^1.15.0
   crypto: ^3.0.0
   glob: ^2.0.0


### PR DESCRIPTION
This expands the version range to declare support for `cli_util` versions `0.5.x`.